### PR TITLE
feat: add daily IC and AUC uncertainty helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,13 +16,15 @@ jobs:
   build:
     name: Build & Deploy Docs
     runs-on: ubuntu-latest
+    env:
+      DOCS_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -33,12 +35,13 @@ jobs:
         run: uv sync --dev --extra docs
 
       - name: Build docs
-        run: uv run mkdocs build --strict
+        run: uv run mkdocs build
 
       - name: Deploy to website repo
+        if: ${{ env.DOCS_DEPLOY_KEY != '' }}
         uses: cpina/github-action-push-to-another-repository@v1.7.2
         env:
-          SSH_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
+          SSH_DEPLOY_KEY: ${{ env.DOCS_DEPLOY_KEY }}
         with:
           source-directory: site/
           destination-github-username: ml4t

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b15] - 2026-04-30
+
+### Added
+- **Daily-metric uncertainty helpers** for cross-sectional ranking signals
+  (`ml4t.diagnostic.metrics.uncertainty`):
+  - `cross_sectional_auc_series(predictions, labels, ...)` — per-date AUC
+    across the cross-section using a vectorized rank-based Mann-Whitney U
+    formula in pure Polars (no `sklearn` per-date loop).
+  - `compute_ic_uncertainty(daily_ic, horizon, ...)` — bundles naive,
+    Newey-West HAC, and stationary block-bootstrap intervals for the mean
+    of a daily-IC series. The HAC lag defaults to
+    `max(horizon - 1, NW_auto)` because forward returns of horizon `H`
+    induce up to `H-1` lags of serial dependence in the IC.
+  - `compute_auc_uncertainty(daily_auc, horizon, ...)` — analogous wrapper
+    for daily AUC, with the null centred on `null_value=0.5`.
+- All three helpers exported from `ml4t.diagnostic.metrics`.
+
+### Notes
+- These helpers move the primary uncertainty estimate for
+  cross-sectional ranking signals from "fold-level std (N≈8–16 folds)" to
+  the daily-pooled IC/AUC time series (N=hundreds), which is the natural
+  observational unit for daily ranking skill.
+
 ## [0.1.0b13] - 2026-04-22
 
 ### Added

--- a/docs/methods/hac-ic.md
+++ b/docs/methods/hac-ic.md
@@ -244,8 +244,20 @@ has meaningful autocorrelation and naive significance tests cannot be trusted.
 | `pooled_ic()` | Compute a pooled correlation across all supplied observations |
 | `compute_ic_summary_stats()` | Naive IC statistics (no HAC) |
 | `compute_ic_hac_stats()` | HAC-adjusted IC statistics |
+| `compute_ic_uncertainty()` | Bundle of naive, HAC, and block-bootstrap CIs for a daily-IC series (recommended one-call entry point) |
+| `cross_sectional_auc_series()` | Per-date cross-sectional AUC for binary labels (Polars-vectorized Mann-Whitney U) |
+| `compute_auc_uncertainty()` | AUC analogue of `compute_ic_uncertainty()`, centred on `null_value=0.5` |
 | `robust_ic()` | Stationary bootstrap IC with confidence intervals |
 | `compute_ic_by_horizon()` | IC analysis across multiple forward return horizons |
+
+### Recommended one-call entry point
+
+For a daily-IC series pooled across CV folds, `compute_ic_uncertainty(daily_ic, horizon=H)`
+returns mean IC together with three confidence intervals side-by-side: naive
+(independence assumption), HAC (Newey-West, lag = `max(H-1, NW_auto)`), and
+stationary block bootstrap (block length defaults to `max(H, n^{1/3})`).
+Reporting all three lets the reader see how much of the SE inflation comes
+from autocorrelation versus distributional shape.
 
 ## See It In The Book
 

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b14"
+__version__ = "0.1.0b15"
 
 # Sub-modules for advanced usage
 from . import (

--- a/src/ml4t/diagnostic/integration/__init__.py
+++ b/src/ml4t/diagnostic/integration/__init__.py
@@ -34,7 +34,6 @@ from ml4t.diagnostic.integration.report_metadata import BacktestReportMetadata
 
 if TYPE_CHECKING:
     from ml4t.backtest import BacktestResult
-
     from ml4t.diagnostic.evaluation import PortfolioAnalysis
 
 

--- a/src/ml4t/diagnostic/metrics/__init__.py
+++ b/src/ml4t/diagnostic/metrics/__init__.py
@@ -44,6 +44,11 @@ from ml4t.diagnostic.metrics.risk_adjusted import (
     sharpe_ratio_with_ci,
     sortino_ratio,
 )
+from ml4t.diagnostic.metrics.uncertainty import (
+    compute_auc_uncertainty,
+    compute_ic_uncertainty,
+    cross_sectional_auc_series,
+)
 
 __all__ = [
     "hit_rate",
@@ -76,4 +81,7 @@ __all__ = [
     "compute_shap_interactions",
     "analyze_interactions",
     "compute_fold_percentiles",
+    "cross_sectional_auc_series",
+    "compute_ic_uncertainty",
+    "compute_auc_uncertainty",
 ]

--- a/src/ml4t/diagnostic/metrics/uncertainty.py
+++ b/src/ml4t/diagnostic/metrics/uncertainty.py
@@ -1,0 +1,460 @@
+"""Uncertainty quantification for cross-sectional IC and AUC time series.
+
+The estimands here treat the **date** as the unit of observation, not the
+individual asset prediction. For a daily cross-sectional ranking strategy this
+matches the metric of interest ("how well does the model rank assets on a
+typical day?") and avoids mixing time-series and cross-sectional variation.
+
+Three uncertainty estimates are reported side by side:
+
+1. Naive standard error of the mean (assumes independent daily metrics).
+2. HAC / Newey-West standard error (autocorrelation-robust; preferred default).
+3. Stationary block bootstrap percentile interval (nonparametric robustness
+   check).
+
+The HAC lag should match or exceed the forward-return horizon, since
+overlapping forward returns mechanically induce serial dependence in the
+daily-metric series. Callers pass ``horizon`` and the helper picks
+``max(horizon - 1, NW_auto)``.
+
+For per-date AUC across a cross-section, ``cross_sectional_auc_series`` uses
+the rank-based Mann-Whitney U formula in pure Polars, with no Python loop
+over dates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from scipy import stats
+
+from ml4t.diagnostic.metrics.ic_inference import compute_ic_hac_stats
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+# ---------------------------------------------------------------------------
+# Cross-sectional AUC series
+# ---------------------------------------------------------------------------
+
+
+def cross_sectional_auc_series(
+    predictions: pl.DataFrame | pd.DataFrame,
+    labels: pl.DataFrame | pd.DataFrame,
+    pred_col: str = "prediction",
+    label_col: str = "label",
+    date_col: str = "date",
+    entity_col: str | list[str] | None = None,
+    min_obs: int = 10,
+) -> pl.DataFrame | pd.DataFrame:
+    """Compute a per-date cross-sectional AUC time series for binary labels.
+
+    AUC is computed via the Mann-Whitney U identity, which is equivalent to
+    ranking all scores within the date and using
+
+    .. math::
+
+        \\mathrm{AUC} = \\frac{R_+ - n_+(n_+ + 1)/2}{n_+ \\, n_-}
+
+    where :math:`R_+` is the sum of ranks of positive examples and
+    :math:`n_+, n_-` are the positive/negative counts. This is fully
+    vectorized in Polars (rank ``over(date)`` then group-by aggregate), so it
+    avoids ``sklearn.metrics.roc_auc_score`` per-date Python loops.
+
+    Parameters
+    ----------
+    predictions, labels
+        DataFrames with ``date_col`` (and ``entity_col`` if panel data),
+        ``pred_col`` continuous score, ``label_col`` binary ``{0, 1}`` label.
+        May be the same DataFrame.
+    min_obs
+        Minimum cross-section size for a valid per-date AUC. Dates with fewer
+        rows or with no positive or no negative examples emit ``ic = null``.
+
+    Returns
+    -------
+    DataFrame with columns ``[date_col, "auc", "n_obs", "n_pos"]``. Type
+    matches the input (polars in → polars out, pandas in → pandas out).
+    """
+    output_as_pandas = isinstance(predictions, pd.DataFrame)
+
+    join_on: list[str] = [date_col]
+    if entity_col is not None:
+        if isinstance(entity_col, str):
+            join_on.append(entity_col)
+        else:
+            join_on.extend(entity_col)
+
+    pred_pl = (
+        predictions
+        if isinstance(predictions, pl.DataFrame)
+        else pl.from_pandas(cast(pd.DataFrame, predictions))
+    )
+    label_pl = (
+        labels if isinstance(labels, pl.DataFrame) else pl.from_pandas(cast(pd.DataFrame, labels))
+    )
+
+    if pred_col in label_pl.columns and pred_col not in pred_pl.columns:
+        # Caller passed a single combined DataFrame as both arguments.
+        pred_pl = label_pl
+
+    if label_col in pred_pl.columns and pred_pl is label_pl:
+        df = pred_pl
+    else:
+        # Avoid duplicating columns when both inputs are the same DataFrame.
+        if pred_pl is label_pl:
+            df = pred_pl
+        else:
+            df = pred_pl.join(label_pl, on=join_on, how="inner")
+
+    valid_expr = pl.col(pred_col).is_finite() & pl.col(label_col).is_not_null()
+
+    df_valid = df.with_columns(
+        [
+            pl.when(valid_expr).then(pl.col(pred_col)).otherwise(None).alias("__score"),
+            pl.when(valid_expr)
+            .then(pl.col(label_col).cast(pl.Float64))
+            .otherwise(None)
+            .alias("__y"),
+        ]
+    ).with_columns(
+        pl.col("__score").rank(method="average").over(date_col).alias("__rank"),
+    )
+
+    all_dates = df.select(date_col).unique().sort(date_col)
+
+    grouped = df_valid.group_by(date_col, maintain_order=False).agg(
+        [
+            valid_expr.sum().alias("n_obs"),
+            pl.col("__y").sum().alias("n_pos"),
+            (pl.col("__rank") * pl.col("__y")).sum().alias("__r_pos"),
+        ]
+    )
+
+    auc_pl = (
+        all_dates.join(grouped, on=date_col, how="left")
+        .with_columns(
+            [
+                pl.col("n_obs").fill_null(0),
+                pl.col("n_pos").fill_null(0),
+                (pl.col("n_obs") - pl.col("n_pos")).alias("n_neg"),
+            ]
+        )
+        .with_columns(
+            pl.when((pl.col("n_obs") >= min_obs) & (pl.col("n_pos") > 0) & (pl.col("n_neg") > 0))
+            .then(
+                (pl.col("__r_pos") - pl.col("n_pos") * (pl.col("n_pos") + 1) / 2)
+                / (pl.col("n_pos") * pl.col("n_neg"))
+            )
+            .otherwise(None)
+            .alias("auc")
+        )
+        .select([date_col, "auc", "n_obs", "n_pos"])
+        .sort(date_col)
+    )
+
+    if output_as_pandas:
+        return auc_pl.to_pandas()
+    return auc_pl
+
+
+# ---------------------------------------------------------------------------
+# Block bootstrap of the mean of a daily metric series
+# ---------------------------------------------------------------------------
+
+
+def _stationary_bootstrap_block_indices(
+    n: int, block_size: float, rng: np.random.Generator
+) -> NDArray[np.int_]:
+    """Generate one stationary-bootstrap index sequence of length ``n``."""
+    p = 1.0 / max(block_size, 1.0)
+    indices = np.empty(n, dtype=np.int_)
+    i = 0
+    while i < n:
+        start = int(rng.integers(0, n))
+        block_len = int(rng.geometric(p))
+        end = min(i + block_len, n)
+        for k in range(end - i):
+            indices[i + k] = (start + k) % n
+        i = end
+    return indices
+
+
+def _block_bootstrap_mean_ci(
+    values: NDArray[Any],
+    *,
+    block_size: float,
+    n_boot: int,
+    alpha: float,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Block-bootstrap percentile CI for the mean of a univariate series."""
+    if values.size < 3:
+        return {
+            "mean": float(np.nan),
+            "ci_lower": float(np.nan),
+            "ci_upper": float(np.nan),
+            "block_size": float(block_size),
+            "n_boot": 0,
+        }
+
+    rng = np.random.default_rng(seed)
+    n = values.size
+    means = np.empty(n_boot, dtype=np.float64)
+    for b in range(n_boot):
+        idx = _stationary_bootstrap_block_indices(n, block_size, rng)
+        means[b] = float(np.mean(values[idx]))
+
+    lo = float(np.percentile(means, 100 * (alpha / 2)))
+    hi = float(np.percentile(means, 100 * (1 - alpha / 2)))
+    return {
+        "mean": float(np.mean(values)),
+        "ci_lower": lo,
+        "ci_upper": hi,
+        "block_size": float(block_size),
+        "n_boot": int(n_boot),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Daily-metric uncertainty wrapper (IC and AUC)
+# ---------------------------------------------------------------------------
+
+
+def _to_daily_array(
+    daily_series: pl.DataFrame | pd.DataFrame | pl.Series | pd.Series | NDArray[Any],
+    value_col: str,
+) -> NDArray[Any]:
+    """Extract the daily metric values as a 1-D float array."""
+    if isinstance(daily_series, pl.DataFrame):
+        arr = daily_series[value_col].to_numpy()
+    elif isinstance(daily_series, pd.DataFrame):
+        arr = daily_series[value_col].to_numpy()
+    elif isinstance(daily_series, pl.Series | pd.Series):
+        arr = np.asarray(daily_series)
+    else:
+        arr = np.asarray(daily_series).flatten()
+    arr = np.asarray(arr, dtype=np.float64).flatten()
+    return arr[np.isfinite(arr)]
+
+
+def _newey_west_lag(n: int, horizon: int) -> int:
+    """HAC lag = max(horizon - 1, Newey-West auto), capped at n // 2."""
+    nw_auto = int(np.floor(4 * (max(n, 1) / 100) ** (2 / 9)))
+    nw_auto = max(1, nw_auto)
+    base = max(horizon - 1, nw_auto)
+    return max(1, min(base, max(1, n // 2)))
+
+
+def compute_ic_uncertainty(
+    daily_ic: pl.DataFrame | pd.DataFrame | pl.Series | pd.Series | NDArray[Any],
+    horizon: int = 1,
+    *,
+    ic_col: str = "ic",
+    alpha: float = 0.05,
+    n_boot: int = 2000,
+    block_size: float | None = None,
+    kernel: str = "bartlett",
+    seed: int = 0,
+) -> dict[str, float | int]:
+    """Bundle naive, HAC, and block-bootstrap uncertainty for a daily-IC series.
+
+    The input is the per-date IC series produced by
+    :func:`cross_sectional_ic_series`, optionally pooled across folds. Each
+    valid (non-null) row is treated as one observation of the daily IC.
+
+    The HAC lag is ``max(horizon - 1, Newey-West auto)`` because overlapping
+    forward returns of horizon ``H`` induce up to ``H - 1`` lags of serial
+    dependence in the IC. The block bootstrap uses an expected block size of
+    at least ``horizon``.
+
+    Returns
+    -------
+    dict with keys
+        ``mean_ic, std_ic, n_days, pct_positive``,
+        ``se_naive, ci_naive_lower, ci_naive_upper``,
+        ``se_hac, ci_hac_lower, ci_hac_upper, t_hac, p_hac, hac_lag``,
+        ``ci_boot_lower, ci_boot_upper, boot_block_size, n_boot``.
+    """
+    values = _to_daily_array(daily_ic, ic_col)
+    n = int(values.size)
+
+    out: dict[str, float | int] = {
+        "mean_ic": float(np.nan),
+        "std_ic": float(np.nan),
+        "n_days": n,
+        "pct_positive": float(np.nan),
+        "se_naive": float(np.nan),
+        "ci_naive_lower": float(np.nan),
+        "ci_naive_upper": float(np.nan),
+        "se_hac": float(np.nan),
+        "ci_hac_lower": float(np.nan),
+        "ci_hac_upper": float(np.nan),
+        "t_hac": float(np.nan),
+        "p_hac": float(np.nan),
+        "hac_lag": 0,
+        "ci_boot_lower": float(np.nan),
+        "ci_boot_upper": float(np.nan),
+        "boot_block_size": float("nan"),
+        "n_boot": 0,
+    }
+
+    if n < 3:
+        return out
+
+    mean_ic = float(np.mean(values))
+    std_ic = float(np.std(values, ddof=1))
+    out["mean_ic"] = mean_ic
+    out["std_ic"] = std_ic
+    out["pct_positive"] = float(np.mean(values > 0))
+
+    # Naive SE / CI (assumes independence — included as a sanity baseline).
+    se_naive = std_ic / np.sqrt(n) if std_ic > 0 else float(np.nan)
+    out["se_naive"] = float(se_naive)
+    if np.isfinite(se_naive) and se_naive > 0:
+        t_crit = float(stats.t.ppf(1 - alpha / 2, df=n - 1))
+        out["ci_naive_lower"] = mean_ic - t_crit * se_naive
+        out["ci_naive_upper"] = mean_ic + t_crit * se_naive
+
+    # HAC SE / CI via existing compute_ic_hac_stats.
+    hac_lag = _newey_west_lag(n, int(max(1, horizon)))
+    hac = compute_ic_hac_stats(
+        pl.DataFrame({ic_col: values}),
+        ic_col=ic_col,
+        maxlags=hac_lag,
+        kernel=kernel,
+    )
+    se_hac = float(hac["hac_se"])
+    out["se_hac"] = se_hac
+    out["t_hac"] = float(hac["t_stat"])
+    out["p_hac"] = float(hac["p_value"])
+    out["hac_lag"] = int(hac["effective_lags"])
+    if np.isfinite(se_hac) and se_hac > 0:
+        t_crit = float(stats.t.ppf(1 - alpha / 2, df=n - 1))
+        out["ci_hac_lower"] = mean_ic - t_crit * se_hac
+        out["ci_hac_upper"] = mean_ic + t_crit * se_hac
+
+    # Block bootstrap. Block size defaults to the larger of the horizon and
+    # n^{1/3}, which is a standard rule of thumb for stationary bootstrap.
+    if block_size is None:
+        block_size = float(max(int(max(1, horizon)), max(1, int(round(n ** (1 / 3))))))
+    boot = _block_bootstrap_mean_ci(
+        values,
+        block_size=float(block_size),
+        n_boot=int(n_boot),
+        alpha=alpha,
+        seed=seed,
+    )
+    out["ci_boot_lower"] = boot["ci_lower"]
+    out["ci_boot_upper"] = boot["ci_upper"]
+    out["boot_block_size"] = boot["block_size"]
+    out["n_boot"] = boot["n_boot"]
+
+    return out
+
+
+def compute_auc_uncertainty(
+    daily_auc: pl.DataFrame | pd.DataFrame | pl.Series | pd.Series | NDArray[Any],
+    horizon: int = 1,
+    *,
+    auc_col: str = "auc",
+    null_value: float = 0.5,
+    alpha: float = 0.05,
+    n_boot: int = 2000,
+    block_size: float | None = None,
+    kernel: str = "bartlett",
+    seed: int = 0,
+) -> dict[str, float | int]:
+    """Daily-AUC analogue of :func:`compute_ic_uncertainty`.
+
+    AUC is centered on ``null_value`` (default 0.5) for the HAC t-statistic
+    and p-value, since the relevant null hypothesis is "AUC = chance" rather
+    than "AUC = 0". All other quantities mirror the IC version.
+
+    Returns the same keys as :func:`compute_ic_uncertainty` with ``ic`` →
+    ``auc`` (e.g. ``mean_auc``, ``ci_hac_lower``, ``ci_hac_upper``, ...).
+    """
+    values = _to_daily_array(daily_auc, auc_col)
+    n = int(values.size)
+
+    out: dict[str, float | int] = {
+        "mean_auc": float(np.nan),
+        "std_auc": float(np.nan),
+        "n_days": n,
+        "pct_above_null": float(np.nan),
+        "se_naive": float(np.nan),
+        "ci_naive_lower": float(np.nan),
+        "ci_naive_upper": float(np.nan),
+        "se_hac": float(np.nan),
+        "ci_hac_lower": float(np.nan),
+        "ci_hac_upper": float(np.nan),
+        "t_hac": float(np.nan),
+        "p_hac": float(np.nan),
+        "hac_lag": 0,
+        "ci_boot_lower": float(np.nan),
+        "ci_boot_upper": float(np.nan),
+        "boot_block_size": float("nan"),
+        "n_boot": 0,
+    }
+
+    if n < 3:
+        return out
+
+    mean_auc = float(np.mean(values))
+    std_auc = float(np.std(values, ddof=1))
+    out["mean_auc"] = mean_auc
+    out["std_auc"] = std_auc
+    out["pct_above_null"] = float(np.mean(values > null_value))
+
+    se_naive = std_auc / np.sqrt(n) if std_auc > 0 else float(np.nan)
+    out["se_naive"] = float(se_naive)
+    if np.isfinite(se_naive) and se_naive > 0:
+        t_crit = float(stats.t.ppf(1 - alpha / 2, df=n - 1))
+        out["ci_naive_lower"] = mean_auc - t_crit * se_naive
+        out["ci_naive_upper"] = mean_auc + t_crit * se_naive
+
+    # HAC: feed (auc - null_value) so the t-statistic tests AUC = null_value.
+    hac_lag = _newey_west_lag(n, int(max(1, horizon)))
+    centered = pl.DataFrame({auc_col: values - null_value})
+    hac = compute_ic_hac_stats(
+        centered,
+        ic_col=auc_col,
+        maxlags=hac_lag,
+        kernel=kernel,
+    )
+    se_hac = float(hac["hac_se"])
+    out["se_hac"] = se_hac
+    out["t_hac"] = float(hac["t_stat"])
+    out["p_hac"] = float(hac["p_value"])
+    out["hac_lag"] = int(hac["effective_lags"])
+    if np.isfinite(se_hac) and se_hac > 0:
+        t_crit = float(stats.t.ppf(1 - alpha / 2, df=n - 1))
+        out["ci_hac_lower"] = mean_auc - t_crit * se_hac
+        out["ci_hac_upper"] = mean_auc + t_crit * se_hac
+
+    if block_size is None:
+        block_size = float(max(int(max(1, horizon)), max(1, int(round(n ** (1 / 3))))))
+    boot = _block_bootstrap_mean_ci(
+        values,
+        block_size=float(block_size),
+        n_boot=int(n_boot),
+        alpha=alpha,
+        seed=seed,
+    )
+    out["ci_boot_lower"] = boot["ci_lower"]
+    out["ci_boot_upper"] = boot["ci_upper"]
+    out["boot_block_size"] = boot["block_size"]
+    out["n_boot"] = boot["n_boot"]
+
+    return out
+
+
+__all__ = [
+    "cross_sectional_auc_series",
+    "compute_ic_uncertainty",
+    "compute_auc_uncertainty",
+]

--- a/src/ml4t/diagnostic/visualization/backtest/overview_elements.py
+++ b/src/ml4t/diagnostic/visualization/backtest/overview_elements.py
@@ -155,7 +155,7 @@ def create_metrics_sidebar_html(metrics: dict[str, Any]) -> str:
                 continue
             formatted = formatter(value)
             value_cls = "metrics-sidebar-value"
-            if neg_is_bad and isinstance(value, (int, float)) and float(value) < 0:
+            if neg_is_bad and isinstance(value, int | float) and float(value) < 0:
                 value_cls += " negative"
             row_parts.append(
                 f'<div class="metrics-sidebar-row">'

--- a/tests/metrics/test_uncertainty.py
+++ b/tests/metrics/test_uncertainty.py
@@ -1,0 +1,207 @@
+"""Tests for cross-sectional AUC and IC/AUC uncertainty helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.metrics import roc_auc_score
+
+from ml4t.diagnostic.metrics import (
+    compute_auc_uncertainty,
+    compute_ic_uncertainty,
+    cross_sectional_auc_series,
+    cross_sectional_ic_series,
+)
+
+# ---------------------------------------------------------------------------
+# cross_sectional_auc_series
+# ---------------------------------------------------------------------------
+
+
+def test_auc_series_matches_sklearn_per_date():
+    rng = np.random.default_rng(0)
+    n_dates = 25
+    n_per_date = 40
+    dates: list[int] = []
+    symbols: list[str] = []
+    preds: list[float] = []
+    labels_list: list[int] = []
+    for d in range(n_dates):
+        scores = rng.normal(size=n_per_date)
+        labels_arr = (scores + rng.normal(scale=2.0, size=n_per_date) > 0).astype(int)
+        for i in range(n_per_date):
+            dates.append(d)
+            symbols.append(f"S{i:03d}")
+            preds.append(float(scores[i]))
+            labels_list.append(int(labels_arr[i]))
+    df = pl.DataFrame({"date": dates, "symbol": symbols, "prediction": preds, "label": labels_list})
+
+    out = cross_sectional_auc_series(df, df, entity_col="symbol", min_obs=5)
+    assert out.columns[:4] == ["date", "auc", "n_obs", "n_pos"]
+
+    aucs_polars = out.drop_nulls("auc").sort("date")["auc"].to_numpy()
+    aucs_sklearn = []
+    for d in df.partition_by("date", maintain_order=True):
+        s = d["prediction"].to_numpy()
+        y = d["label"].to_numpy()
+        if y.min() == y.max():
+            continue
+        aucs_sklearn.append(roc_auc_score(y, s))
+    aucs_sklearn = np.array(aucs_sklearn)
+
+    assert aucs_polars.shape == aucs_sklearn.shape
+    np.testing.assert_allclose(aucs_polars, aucs_sklearn, atol=1e-9)
+
+
+def test_auc_series_handles_degenerate_dates():
+    df = pl.DataFrame(
+        {
+            "date": ["2024-01-01"] * 4 + ["2024-01-02"] * 4 + ["2024-01-03"] * 12,
+            "symbol": [f"S{i}" for i in list(range(4)) * 2 + list(range(12))],
+            "prediction": [0.1, 0.2, 0.3, 0.4]  # all-positive labels day
+            + [0.1, 0.2, 0.3, 0.4]  # all-negative labels day
+            + list(np.linspace(0, 1, 12)),
+            "label": [1, 1, 1, 1] + [0, 0, 0, 0] + [0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1],
+        }
+    )
+    out = cross_sectional_auc_series(df, df, entity_col="symbol", min_obs=4)
+    aucs = dict(zip(out["date"].to_list(), out["auc"].to_list()))
+    assert aucs["2024-01-01"] is None
+    assert aucs["2024-01-02"] is None
+    assert aucs["2024-01-03"] is not None and 0.0 <= aucs["2024-01-03"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_ic_uncertainty
+# ---------------------------------------------------------------------------
+
+
+def test_ic_uncertainty_keys_and_shapes():
+    rng = np.random.default_rng(1)
+    daily = pl.DataFrame({"date": np.arange(400), "ic": rng.normal(0.02, 0.06, size=400)})
+    out = compute_ic_uncertainty(daily, horizon=5, n_boot=200, seed=7)
+
+    expected = {
+        "mean_ic",
+        "std_ic",
+        "n_days",
+        "pct_positive",
+        "se_naive",
+        "ci_naive_lower",
+        "ci_naive_upper",
+        "se_hac",
+        "ci_hac_lower",
+        "ci_hac_upper",
+        "t_hac",
+        "p_hac",
+        "hac_lag",
+        "ci_boot_lower",
+        "ci_boot_upper",
+        "boot_block_size",
+        "n_boot",
+    }
+    assert expected.issubset(out.keys())
+    assert out["n_days"] == 400
+    assert out["hac_lag"] >= 4  # horizon - 1 = 4
+    assert out["n_boot"] == 200
+    assert out["ci_naive_lower"] < out["mean_ic"] < out["ci_naive_upper"]
+    assert out["ci_hac_lower"] < out["mean_ic"] < out["ci_hac_upper"]
+    assert out["ci_boot_lower"] < out["mean_ic"] < out["ci_boot_upper"]
+
+
+def test_ic_uncertainty_short_series_returns_nan():
+    out = compute_ic_uncertainty(pl.DataFrame({"ic": [0.1, 0.2]}), horizon=1, n_boot=50)
+    assert out["n_days"] == 2
+    assert np.isnan(out["mean_ic"])
+    assert np.isnan(out["se_hac"])
+
+
+def test_ic_uncertainty_hac_widens_with_positive_autocorr():
+    """Positively autocorrelated IC series → HAC SE > naive SE."""
+    rng = np.random.default_rng(42)
+    n = 600
+    eps = rng.normal(scale=0.05, size=n)
+    rho = 0.6
+    ic = np.zeros(n)
+    for t in range(1, n):
+        ic[t] = rho * ic[t - 1] + eps[t]
+    ic = ic + 0.02
+    out = compute_ic_uncertainty(pl.DataFrame({"ic": ic}), horizon=5, n_boot=300, seed=11)
+    assert out["se_hac"] > out["se_naive"]
+    assert out["ci_hac_upper"] - out["ci_hac_lower"] > out["ci_naive_upper"] - out["ci_naive_lower"]
+
+
+def test_ic_uncertainty_accepts_series_array_dataframe():
+    rng = np.random.default_rng(3)
+    arr = rng.normal(0.01, 0.05, size=300)
+    a = compute_ic_uncertainty(arr, horizon=1, n_boot=100, seed=0)
+    b = compute_ic_uncertainty(pl.Series(arr), horizon=1, n_boot=100, seed=0)
+    c = compute_ic_uncertainty(pl.DataFrame({"ic": arr}), horizon=1, n_boot=100, seed=0)
+    assert a["mean_ic"] == pytest.approx(b["mean_ic"])
+    assert a["mean_ic"] == pytest.approx(c["mean_ic"])
+    assert a["se_hac"] == pytest.approx(b["se_hac"])
+    assert a["se_hac"] == pytest.approx(c["se_hac"])
+
+
+# ---------------------------------------------------------------------------
+# compute_auc_uncertainty
+# ---------------------------------------------------------------------------
+
+
+def test_auc_uncertainty_centers_on_null_value():
+    rng = np.random.default_rng(5)
+    daily = pl.DataFrame({"auc": 0.5 + rng.normal(0.04, 0.05, size=300)})
+    out = compute_auc_uncertainty(daily, horizon=5, n_boot=200, seed=2)
+    assert "mean_auc" in out
+    assert out["mean_auc"] == pytest.approx(np.mean(daily["auc"].to_numpy()), rel=1e-6)
+    # H0 here is AUC = 0.5; mean is 0.54-ish so t-stat should be positive
+    assert out["t_hac"] > 0
+
+
+def test_auc_uncertainty_chance_level_ci_contains_null():
+    """Chance-level AUC: HAC CI should straddle 0.5 most of the time."""
+    contains_null = 0
+    n_trials = 25
+    for s in range(n_trials):
+        rng = np.random.default_rng(100 + s)
+        daily = pl.DataFrame({"auc": 0.5 + rng.normal(0, 0.03, size=300)})
+        out = compute_auc_uncertainty(daily, horizon=1, n_boot=100, seed=s)
+        if out["ci_hac_lower"] <= 0.5 <= out["ci_hac_upper"]:
+            contains_null += 1
+    # 95% CI should cover the null in the vast majority of trials
+    assert contains_null >= 20
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: ic_series → uncertainty
+# ---------------------------------------------------------------------------
+
+
+def test_ic_series_to_uncertainty_pipeline():
+    rng = np.random.default_rng(13)
+    n_dates = 200
+    n_per = 50
+    dates: list[int] = []
+    symbols: list[str] = []
+    preds: list[float] = []
+    rets: list[float] = []
+    for d in range(n_dates):
+        eps = rng.normal(scale=1.0, size=n_per)
+        ret = rng.normal(scale=1.0, size=n_per)
+        pred = 0.15 * ret + eps
+        for i in range(n_per):
+            dates.append(d)
+            symbols.append(f"S{i}")
+            preds.append(float(pred[i]))
+            rets.append(float(ret[i]))
+    df = pl.DataFrame(
+        {"date": dates, "symbol": symbols, "prediction": preds, "forward_return": rets}
+    )
+    series = cross_sectional_ic_series(df, df, entity_col="symbol", min_obs=5)
+    unc = compute_ic_uncertainty(series, horizon=1, n_boot=300, seed=21)
+
+    assert unc["mean_ic"] > 0  # weak positive signal
+    assert unc["ci_hac_lower"] > -0.5
+    assert unc["ci_hac_upper"] < 0.5
+    assert unc["n_days"] >= 100

--- a/tests/test_integration/test_backtest_profile.py
+++ b/tests/test_integration/test_backtest_profile.py
@@ -4,9 +4,9 @@ from datetime import UTC, datetime, timedelta
 
 import polars as pl
 import pytest
+
 from ml4t.backtest import BacktestResult
 from ml4t.backtest.types import Fill, OrderSide, Trade
-
 from ml4t.diagnostic.integration import analyze_backtest_result
 
 

--- a/tests/test_integration/test_backtest_result.py
+++ b/tests/test_integration/test_backtest_result.py
@@ -10,10 +10,9 @@ from types import SimpleNamespace
 import numpy as np
 import polars as pl
 import pytest
+
 from ml4t.backtest import BacktestConfig, BacktestResult
 from ml4t.backtest.types import Trade
-from ml4t.specs import FeedSpec
-
 from ml4t.diagnostic.integration import (
     BacktestReportMetadata,
     compute_metrics_from_result,
@@ -22,6 +21,7 @@ from ml4t.diagnostic.integration import (
     portfolio_analysis_from_result,
     profile_from_run_artifacts,
 )
+from ml4t.specs import FeedSpec
 
 
 def create_sample_result(n_trades: int = 20) -> BacktestResult:

--- a/tests/test_visualization/test_backtest.py
+++ b/tests/test_visualization/test_backtest.py
@@ -14,9 +14,9 @@ import numpy as np
 import plotly.graph_objects as go
 import polars as pl
 import pytest
+
 from ml4t.backtest import BacktestResult
 from ml4t.backtest.types import Fill, OrderSide, Trade
-
 from ml4t.diagnostic.integration import BacktestReportMetadata
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add daily IC and AUC uncertainty helpers under `ml4t.diagnostic.metrics`
- document the daily-pooled HAC and stationary bootstrap workflow
- clean up release blockers found during verification (`overview_elements` Ruff issue and stale editable-install metadata check)

## Testing
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run ty check
- uv run mkdocs build --strict
- uv build
- pre-commit run --all-files
- uv run pytest tests/ -q