### PR TITLE
fix: lower python 3.14 scikit-learn floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b17] - 2026-05-05
+
+### Fixed
+- **Python 3.14 scikit-learn floor**: lowered the Python 3.14 `scikit-learn`
+  requirement from `>=1.8.0` to `>=1.7.2`, which already publishes `cp314`
+  wheels and avoids unnecessary dependency conflicts with downstream libraries.
+- **Transitive dependency floor**: updated the `ml4t-engineer` dependency to
+  `>=0.1.0b6`, the first release that also lowers its Python 3.14
+  `scikit-learn` floor to `>=1.7.2`.
+
 ## [0.1.0b16] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requires-python = ">=3.12,<3.15"
 
 # Core dependencies
 dependencies = [
-    "ml4t-engineer>=0.1.0b5",
+    "ml4t-engineer>=0.1.0b6",
     "ml4t-specs>=0.1.0b0",
 
     # Data processing
@@ -80,7 +80,7 @@ dependencies = [
     "scipy>=1.10.0; python_version < '3.14'",
     "scipy>=1.17.0; python_version >= '3.14'",
     "scikit-learn>=1.3.0; python_version < '3.14'",
-    "scikit-learn>=1.8.0; python_version >= '3.14'",
+    "scikit-learn>=1.7.2; python_version >= '3.14'",
     "joblib>=1.3.0",
     "statsmodels>=0.14.0; python_version < '3.14'",
     "statsmodels>=0.14.6; python_version >= '3.14'",

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b16"
+__version__ = "0.1.0b17"
 
 # Sub-modules for advanced usage
 from . import (

--- a/tests/test_core/test_numba_utils.py
+++ b/tests/test_core/test_numba_utils.py
@@ -348,7 +348,7 @@ class TestNumbaEdgeCases:
     @given(
         size=st.integers(min_value=10, max_value=100),
     )
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     def test_ic_bounds(self, size):
         """Property: IC should always be in [-1, 1]."""
         np.random.seed(42)

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ requires-dist = [
     { name = "ml4t-data", marker = "extra == 'all'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'data'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'factors'", specifier = ">=0.1.0b7" },
-    { name = "ml4t-engineer", specifier = ">=0.1.0b5" },
+    { name = "ml4t-engineer", specifier = ">=0.1.0b6" },
     { name = "ml4t-specs", specifier = ">=0.1.0b0" },
     { name = "numba", marker = "python_full_version < '3.14'", specifier = ">=0.57.0" },
     { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.64.0" },
@@ -1815,7 +1815,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "scikit-learn", marker = "python_full_version < '3.14'", specifier = ">=1.3.0" },
-    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.8.0" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.7.2" },
     { name = "scipy", marker = "python_full_version < '3.14'", specifier = ">=1.10.0" },
     { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.17.0" },
     { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.12.0" },
@@ -1858,7 +1858,7 @@ dev = [
 
 [[package]]
 name = "ml4t-engineer"
-version = "0.1.0b5"
+version = "0.1.0b6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
@@ -1883,9 +1883,9 @@ dependencies = [
     { name = "statsmodels", version = "0.14.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/ca/f0b6968f6ad3fcbdbc86a59591f6da42c8a53d6d74cd9e4cc20f9124bca6/ml4t_engineer-0.1.0b5.tar.gz", hash = "sha256:9de75aedc8a187cd7ffc9be6b566936aab555052bc0f6eee9a987a1f69984948", size = 539792, upload-time = "2026-05-05T12:40:53.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/97/d120eab90c1d0a50a165adf2b4f0d72511cdd648ed016b0a2bdf7852c277/ml4t_engineer-0.1.0b6.tar.gz", hash = "sha256:ec72bfb5d2ceea37b0b1c309717cb2bbde01a3b05bff8fffc9305d44558b7b03", size = 539889, upload-time = "2026-05-05T15:46:13.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/85/4f25d7b475dca03f37119f6b5f687173077794472a6b48607bef6ad47b50/ml4t_engineer-0.1.0b5-py3-none-any.whl", hash = "sha256:026f9a7b68bfe19e434add4b45a425ddfa89f9c0ae919db2e1d3556bc9112ac6", size = 363158, upload-time = "2026-05-05T12:40:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/01b364fcef160b4eaf819865cf54da2d697d858b4fc9fc5fe57c74e7dd0c/ml4t_engineer-0.1.0b6-py3-none-any.whl", hash = "sha256:74d180fc91ab1c9c06cdf5d3144993f5e98dc13b4726070e7fcc44a00f9898fa", size = 363159, upload-time = "2026-05-05T15:46:11.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- lower the Python 3.14 scikit-learn floor from >=1.8.0 to >=1.7.2
- require ml4t-engineer>=0.1.0b6 so the transitive Python 3.14 floor matches
- stabilize the Numba IC property test by disabling the Hypothesis deadline for JIT warmup

## Validation
- uv run ruff check src tests .github
- uv build
- uv run pytest tests/ -q
- exact-minimum Python 3.14 check with scikit-learn==1.7.2: 5211 passed, 21 skipped