### PR TITLE
fix: lower python 3.14 pandas floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b18] - 2026-05-05
+
+### Fixed
+- **Python 3.14 pandas floor**: lowered the Python 3.14 `pandas`
+  requirement from `>=3.0.0` to `>=2.3.3`, which already publishes `cp314`
+  wheels and avoids unnecessary dependency conflicts with downstream libraries.
+- **Transitive dependency floor**: updated the `ml4t-engineer` dependency to
+  `>=0.1.0b7`, the first release that also lowers its Python 3.14 `pandas`
+  floor to `>=2.3.3`.
+
 ## [0.1.0b17] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,13 +66,13 @@ requires-python = ">=3.12,<3.15"
 
 # Core dependencies
 dependencies = [
-    "ml4t-engineer>=0.1.0b6",
+    "ml4t-engineer>=0.1.0b7",
     "ml4t-specs>=0.1.0b0",
 
     # Data processing
     "polars>=0.20.0",
     "pandas>=2.0.0; python_version < '3.14'",
-    "pandas>=3.0.0; python_version >= '3.14'",
+    "pandas>=2.3.3; python_version >= '3.14'",
     "numpy>=1.24.0",
     "pyarrow>=14.0.0; python_version < '3.14'",
     "pyarrow>=23.0.0; python_version >= '3.14'",

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b17"
+__version__ = "0.1.0b18"
 
 # Sub-modules for advanced usage
 from . import (

--- a/uv.lock
+++ b/uv.lock
@@ -1790,13 +1790,13 @@ requires-dist = [
     { name = "ml4t-data", marker = "extra == 'all'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'data'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'factors'", specifier = ">=0.1.0b7" },
-    { name = "ml4t-engineer", specifier = ">=0.1.0b6" },
+    { name = "ml4t-engineer", specifier = ">=0.1.0b7" },
     { name = "ml4t-specs", specifier = ">=0.1.0b0" },
     { name = "numba", marker = "python_full_version < '3.14'", specifier = ">=0.57.0" },
     { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.64.0" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pandas", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
-    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=3.0.0" },
+    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
     { name = "pandas-market-calendars", specifier = ">=4.0.0" },
     { name = "plotly", marker = "extra == 'all'", specifier = ">=5.15.0" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.15.0" },
@@ -1858,7 +1858,7 @@ dev = [
 
 [[package]]
 name = "ml4t-engineer"
-version = "0.1.0b6"
+version = "0.1.0b7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
@@ -1883,9 +1883,9 @@ dependencies = [
     { name = "statsmodels", version = "0.14.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/97/d120eab90c1d0a50a165adf2b4f0d72511cdd648ed016b0a2bdf7852c277/ml4t_engineer-0.1.0b6.tar.gz", hash = "sha256:ec72bfb5d2ceea37b0b1c309717cb2bbde01a3b05bff8fffc9305d44558b7b03", size = 539889, upload-time = "2026-05-05T15:46:13.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/0c/2027dafe5976a01b02ada57afd45121b84fadd5cf24f186a3d5a2121e709/ml4t_engineer-0.1.0b7.tar.gz", hash = "sha256:ca05202fac42edadf47d873ea78d63fe0c1b32b87c5e56d2287428ed40aab088", size = 539932, upload-time = "2026-05-05T19:03:20.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/f4/01b364fcef160b4eaf819865cf54da2d697d858b4fc9fc5fe57c74e7dd0c/ml4t_engineer-0.1.0b6-py3-none-any.whl", hash = "sha256:74d180fc91ab1c9c06cdf5d3144993f5e98dc13b4726070e7fcc44a00f9898fa", size = 363159, upload-time = "2026-05-05T15:46:11.523Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/51/69aa72bb7d82663860b423d3ac54403f5572af29f116d36036e3e09196ae/ml4t_engineer-0.1.0b7-py3-none-any.whl", hash = "sha256:ddbd63684b254d4dbb79e41e838a69a4e02b9d0d28bf3eceb2e78b8901c90d08", size = 363160, upload-time = "2026-05-05T19:03:18.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- lower the Python 3.14 pandas floor from >=3.0.0 to >=2.3.3
- require ml4t-engineer>=0.1.0b7 so the transitive Python 3.14 pandas floor matches
- keep the previous Python 3.14 scikit-learn floor and Numba test stabilization unchanged

## Validation
- uv run ruff check src tests .github
- uv run ty check
- uv build
- uv run pytest tests/ -q: 5211 passed, 21 skipped
- exact-minimum Python 3.14 check with pandas==2.3.3 and ml4t-engineer==0.1.0b7: 5211 passed, 21 skipped