### PR TITLE
fix: relax python 3.14 dependency pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b19] - 2026-05-05
+
+### Fixed
+- **Removed Python 3.14 dependency split pins**: dropped the Python 3.14-only
+  minimum overrides for `pandas`, `pyarrow`, `scipy`, `scikit-learn`,
+  `statsmodels`, `numba`, and `arch`, keeping the source-level minimums as the
+  unconditional package requirements.
+- **Transitive dependency floor**: updated `ml4t-engineer` to `>=0.1.0b8`,
+  the first release that also removes its Python 3.14-only dependency split
+  pins.
+
 ## [0.1.0b18] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,27 +66,21 @@ requires-python = ">=3.12,<3.15"
 
 # Core dependencies
 dependencies = [
-    "ml4t-engineer>=0.1.0b7",
+    "ml4t-engineer>=0.1.0b8",
     "ml4t-specs>=0.1.0b0",
 
     # Data processing
     "polars>=0.20.0",
-    "pandas>=2.0.0; python_version < '3.14'",
-    "pandas>=2.3.3; python_version >= '3.14'",
+    "pandas>=2.0.0",
     "numpy>=1.24.0",
-    "pyarrow>=14.0.0; python_version < '3.14'",
-    "pyarrow>=23.0.0; python_version >= '3.14'",
+    "pyarrow>=14.0.0",
     # Scientific computing
-    "scipy>=1.10.0; python_version < '3.14'",
-    "scipy>=1.17.0; python_version >= '3.14'",
-    "scikit-learn>=1.3.0; python_version < '3.14'",
-    "scikit-learn>=1.7.2; python_version >= '3.14'",
+    "scipy>=1.10.0",
+    "scikit-learn>=1.3.0",
     "joblib>=1.3.0",
-    "statsmodels>=0.14.0; python_version < '3.14'",
-    "statsmodels>=0.14.6; python_version >= '3.14'",
+    "statsmodels>=0.14.0",
     # Performance optimization
-    "numba>=0.57.0; python_version < '3.14'",
-    "numba>=0.64.0; python_version >= '3.14'",
+    "numba>=0.57.0",
     "tqdm>=4.66.0",
     # Configuration management
     "pydantic>=2.0.0",
@@ -95,8 +89,7 @@ dependencies = [
     "pandas_market_calendars>=4.0.0",
     # Templating (needed for dashboard module)
     "jinja2>=3.1.0",
-    "arch>=7.2.0; python_version < '3.14'",
-    "arch>=8.0.0; python_version >= '3.14'",
+    "arch>=7.2.0",
     "shap>=0.41.0,<0.52.0",
 ]
 

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b18"
+__version__ = "0.1.0b19"
 
 # Sub-modules for advanced usage
 from . import (


### PR DESCRIPTION
Summary:
- drop Python 3.14-specific split pins for pandas, pyarrow, scipy, scikit-learn, statsmodels, numba, and arch
- keep the package source-level minimums unconditional so downstream resolvers can choose newer compatible builds
- bump ml4t-engineer floor to the matching release

Verification:
- constrained Python 3.14 resolution with pandas==2.3.3 and scikit-learn==1.6.1 succeeded
- full suite under that constrained environment: 5211 passed, 21 skipped
- uv build passed