### PR TITLE
feat: add correlation-adjusted deflated sharpe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b20] - 2026-05-11
+
+### Added
+- **Correlation-adjusted Deflated Sharpe Ratio**: added
+  `effective_number_of_trials()` with `effective_rank`,
+  `marchenko_pastur`, and `clustering` estimators so DSR can use
+  `K_eff` instead of raw `K` for correlated strategy cohorts.
+- **Correlation-aware DSR metadata**: `DSRResult` and `DSRResultSchema`
+  now report `n_trials_raw`, `n_trials_effective`, `correlation_method`,
+  and `min_k_eff`.
+- **2D strategy matrix support for DSR**: `deflated_sharpe_ratio()`
+  now accepts either a sequence of return series or a
+  `(n_periods, n_strategies)` return matrix for multi-strategy evaluation.
+
+### Changed
+- **DSR documentation and agent guidance**: updated public docs and
+  packaged `AGENTS.md` files to cover `K_eff`, cadence-sensitive
+  `periods_per_year`, and the conservative `min_k_eff` floor.
+
+### Fixed
+- **Pandas 3 timestamp handling**: hardened purging and walk-forward
+  splitter searchsorted logic plus calendar period grouping for modern
+  pandas datetime unit semantics.
+- **XGBoost MDI feature names**: fixed the fallback path so classical
+  importance results still emit stable feature names when the booster
+  omits them.
+
 ## [0.1.0b19] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Together they cover data infrastructure, feature engineering, modeling, signal e
 Evaluating whether a signal or strategy has genuine predictive power requires statistical rigor. ml4t-diagnostic provides:
 
 - Information coefficient (IC) analysis with HAC-adjusted standard errors
-- Deflated Sharpe Ratio (DSR) and other multiple-testing corrections (RAS, PBO, FDR)
+- Deflated Sharpe Ratio (DSR) with correlation-adjusted K_eff plus other multiple-testing corrections (RAS, PBO, FDR)
 - Combinatorial purged cross-validation (CPCV) with calendar-aware splitting
 - Feature importance analysis (MDI, PFI, MDA, SHAP) with consensus ranking
 - Trade-level diagnostics with SHAP-based error pattern discovery
@@ -109,15 +109,19 @@ html = generate_tearsheet_from_result(
 ```python
 from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
 
-# Accounts for multiple testing
+# Accounts for multiple testing across correlated strategy variants
 dsr_result = deflated_sharpe_ratio(
-    returns=strategy_returns,
+    returns=[strategy_a_returns, strategy_b_returns, strategy_c_returns],
     benchmark_sharpe=0.0,
-    n_trials=100,
+    correlation_method="effective_rank",
+    min_k_eff=2.0,
+    periods_per_year=252,
 )
 
 print(f"Sharpe: {dsr_result.sharpe_ratio:.2f}")
 print(f"Deflated Sharpe: {dsr_result.deflated_sharpe:.2f}")
+print(f"Raw trials: {dsr_result.n_trials_raw}")
+print(f"Effective trials: {dsr_result.n_trials_effective:.2f}")
 print(f"Significant: {dsr_result.is_significant}")
 ```
 

--- a/docs/methods/deflated-sharpe-ratio.md
+++ b/docs/methods/deflated-sharpe-ratio.md
@@ -17,9 +17,13 @@ $$
 E[\max\{SR\}] \approx \sqrt{\text{Var}[\{SR_k\}]} \cdot \sqrt{2 \log K}
 $$
 
-For K=50 strategies with typical variance, this spurious maximum is around 0.4-0.8 --
-enough to look like a tradeable signal. This is **selection bias**, and it is the
-most common source of backtest overfitting.
+For K=50 strategies with typical variance, this spurious maximum is around
+0.4-0.8 -- enough to look like a tradeable signal. This is **selection bias**,
+and it is the most common source of backtest overfitting.
+
+When the trial cohort is highly correlated, raw K can be too conservative.
+`ml4t-diagnostic` therefore also supports correlation-adjusted
+`K_eff` via `effective_rank`, `marchenko_pastur`, and `clustering`.
 
 ## The Solution
 
@@ -76,6 +80,7 @@ survives multiple testing correction at the 5% level.
 from ml4t.diagnostic.evaluation.stats import (
     deflated_sharpe_ratio,
     deflated_sharpe_ratio_from_statistics,
+    effective_number_of_trials,
 )
 import numpy as np
 
@@ -87,12 +92,23 @@ trial_returns = [
     np.random.normal(0.0002, 0.012, 252),
 ]
 
-result = deflated_sharpe_ratio(trial_returns, frequency="daily")
+k_eff = effective_number_of_trials(
+    np.column_stack(trial_returns),
+    method="effective_rank",
+)
+
+result = deflated_sharpe_ratio(
+    trial_returns,
+    frequency="daily",
+    correlation_method="effective_rank",
+    min_k_eff=2.0,
+)
 
 print(f"Probability of skill: {result.probability:.3f}")
 print(f"P-value: {result.p_value:.3f}")
 print(f"Expected max from noise: {result.expected_max_sharpe:.3f}")
 print(f"Deflated Sharpe: {result.deflated_sharpe:.3f}")
+print(f"K_eff: {result.n_trials_effective:.2f} (raw K={result.n_trials_raw})")
 
 # Secondary path: use pre-computed statistics if your pipeline already has them
 stats_result = deflated_sharpe_ratio_from_statistics(
@@ -101,6 +117,9 @@ stats_result = deflated_sharpe_ratio_from_statistics(
     n_trials=50,
     variance_trials=0.03,
     frequency="daily",
+    effective_trials=8.5,
+    correlation_method="effective_rank",
+    min_k_eff=2.0,
 )
 ```
 
@@ -117,8 +136,26 @@ Sharpe moments and trial variance upstream.
 | `frequency` | Return frequency | `"daily"` by default; affects annualized display values |
 | `benchmark_sharpe` | Null-hypothesis Sharpe threshold | Leave at `0.0` unless you need a stricter hurdle |
 | `n_trials` | Total strategies tested | Relevant for the statistics-based helper; include all trials |
+| `correlation_method` | Correlation-aware `K_eff` estimator | Use `"effective_rank"` first; compare against `"marchenko_pastur"` or `"clustering"` when needed |
+| `min_k_eff` | Conservative floor for correlation-adjusted `K_eff` | Leave at `1.0` by default; raise only when you want an explicit residual multiplicity penalty |
 | `variance_trials` | Var[{SR_1, ..., SR_K}] across all strategies | Must be computed, not assumed, when using the statistics-based helper |
 | `n_samples` | Number of return observations | T >= 50 minimum, >= 252 recommended |
+
+### Correlation-Adjusted Trial Counts
+
+When your candidate strategies are closely related, raw `K` can overstate the
+true breadth of the search. The library supports three estimators for
+correlation-adjusted `K_eff`:
+
+| Estimator | What it measures | Notes |
+|-----------|------------------|-------|
+| `effective_rank` | entropy-weighted eigenvalue breadth | Recommended default; smooth and cheap |
+| `marchenko_pastur` | non-noise eigenvalue count | Uses the iterative denoising variant |
+| `clustering` | number of independent strategy families | Also swaps in cluster-level Sharpe variance |
+
+The `deflated_sharpe_ratio()` result reports both `n_trials_raw` and
+`n_trials_effective`. If `min_k_eff > 1`, `n_trials_effective` reflects the
+post-floor value actually used in the DSR adjustment.
 
 ## Interpreting Results
 
@@ -145,19 +182,25 @@ and realistic transaction cost modeling.
     Every parameter variation, feature combination, and lookback period counts as a trial.
     If you tested 10 signals x 5 lookbacks x 3 thresholds = 150 trials, not 10.
 
-3. **Misinterpreting the output**
+3. **Mixing return cadence and annualization**
+
+    `periods_per_year` should reflect the cadence of the return series passed to
+    DSR, not the rebalance cadence that generated those returns. Daily crypto
+    return series usually need `periods_per_year=365`, not `252`.
+
+4. **Misinterpreting the output**
 
     DSR = 0.42 does **not** mean "the strategy has 42% of its claimed Sharpe."
     It means "there is 42% probability the true Sharpe exceeds zero after
     accounting for multiple testing."
 
-4. **Ignoring non-normality**
+5. **Ignoring non-normality**
 
     Strategies with negative skewness and fat tails (common in trend-following)
     have higher Sharpe ratio estimation variance. Always provide `skewness` and
     `excess_kurtosis` from your actual returns.
 
-5. **Using DSR without enough data**
+6. **Using DSR without enough data**
 
     With T < 50 observations, the standard error of the Sharpe ratio estimator
     is so large that DSR becomes unreliable regardless of the observed value.

--- a/docs/reference/references.md
+++ b/docs/reference/references.md
@@ -70,22 +70,21 @@ Where:
 #### Usage Example
 
 ```python
-from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio_from_statistics
 
-# You tested 50 strategies, selected the best one
-result = deflated_sharpe_ratio(
+# You tested 50 strategies, selected the best one, and already computed the cohort statistics
+result = deflated_sharpe_ratio_from_statistics(
     observed_sharpe=1.5,      # Best strategy's SR
     n_trials=50,              # Number tested
     variance_trials=1.0,      # Var[{SR_1, ..., SR_50}]
     n_samples=252,            # Days of data
     skewness=0.0,             # Return skewness
     excess_kurtosis=0.0,      # Fisher convention (normal=0)
-    return_components=True
 )
 
-print(f"DSR probability: {result['dsr']:.3f}")
-print(f"Expected max under null: {result['expected_max_sharpe']:.3f}")
-print(f"p-value: {result['p_value']:.3f}")
+print(f"DSR probability: {result.probability:.3f}")
+print(f"Expected max under null: {result.expected_max_sharpe:.3f}")
+print(f"p-value: {result.p_value:.3f}")
 ```
 
 **Critical Requirement**: You must provide the **actual variance** of Sharpe ratios across all K strategies tested. DSR cannot be meaningfully calculated without access to all strategies.

--- a/docs/user-guide/statistical-tests.md
+++ b/docs/user-guide/statistical-tests.md
@@ -4,18 +4,25 @@ ML4T Diagnostic implements rigorous statistical tests to prevent false discoveri
 
 ## Deflated Sharpe Ratio (DSR)
 
-The DSR adjusts the Sharpe ratio for the number of backtests tried:
+DSR asks whether the selected leader still looks credible after accounting for
+the fact that you searched across multiple candidates.
 
 ```python
-from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio, effective_number_of_trials
+
+# returns_matrix shape: (n_periods, n_strategies)
+k_eff = effective_number_of_trials(returns_matrix, method="effective_rank")
 
 result = deflated_sharpe_ratio(
-    returns=strategy_returns,
-    n_trials=100,             # How many strategies tested
-    frequency='daily',        # Return frequency
-    periods_per_year=252
+    returns=returns_matrix,
+    frequency="daily",
+    periods_per_year=252,
+    correlation_method="effective_rank",
+    min_k_eff=2.0,
 )
 
+print(f"Raw trials: {result.n_trials_raw}")
+print(f"Effective trials: {result.n_trials_effective:.2f}")
 print(f"Observed Sharpe: {result.sharpe_ratio:.2f}")
 print(f"Deflated Sharpe: {result.deflated_sharpe:.2f}")
 print(f"p-value: {result.p_value:.4f}")
@@ -24,17 +31,26 @@ print(f"p-value: {result.p_value:.4f}")
 ### When to Use DSR
 
 - After trying multiple strategy variations
+- When those variants are strongly correlated and raw K over-penalizes the leader
 - When selecting among several candidate strategies
 - To report statistically honest performance
 
 ### DSR Formula (López de Prado et al. 2025)
 
-$$DSR = \Phi^{-1}\left(1 - e^{-\frac{1}{2}\gamma}\right)$$
+For multiple strategies, DSR replaces the naive null `SR_0 = 0` with an
+expected-maximum Sharpe threshold:
 
-where $\gamma$ accounts for:
-- Number of trials
-- Expected maximum Sharpe under null hypothesis
-- Autocorrelation in returns
+$$
+SR_0 = E[\max\{\widehat{SR}_k\}]
+$$
+
+and then evaluates the leader's Sharpe ratio relative to that harder hurdle.
+When you provide `correlation_method=...`, the library uses `K_eff` instead of
+raw `K` in the False Strategy Theorem adjustment.
+
+`effective_rank` is the recommended default. `marchenko_pastur` uses the
+iterative denoising variant, and `clustering` estimates the number of
+independent strategy families.
 
 See [Deflated Sharpe Ratio](../methods/deflated-sharpe-ratio.md) for details.
 

--- a/docs/user-guide/validation-tiers.md
+++ b/docs/user-guide/validation-tiers.md
@@ -101,9 +101,10 @@ print(signal_result.summary())
 from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
 
 result = deflated_sharpe_ratio(
-    returns=strategy_returns,
-    n_trials=100,
+    returns=strategy_matrix,
     frequency="daily",
+    correlation_method="effective_rank",
+    min_k_eff=2.0,
 )
 
 print(f"Probability of skill: {result.probability:.1%}")

--- a/src/ml4t/diagnostic/AGENTS.md
+++ b/src/ml4t/diagnostic/AGENTS.md
@@ -27,6 +27,10 @@
 
 - Public API is defined by `__all__` exports in package modules.
 - Recent reporting work is centered in `integration/` and `visualization/backtest/`.
+- Correlation-adjusted DSR now lives in `evaluation.stats` via
+  `effective_number_of_trials()` plus `deflated_sharpe_ratio(..., correlation_method=...)`.
+- For book and case-study workflows, set `periods_per_year` from the return
+  series cadence, not from rebalance cadence.
 
 ## Migration Notes For Book Agents
 
@@ -37,3 +41,6 @@
 - Use `plot_ic_term_structure()` for horizon heatmaps and `plot_monthly_ic_heatmap()` for monthly signal IC heatmaps.
 - Pydantic result schemas use explicit names such as `PortfolioMetricsResultSchema`,
   `PSRResultSchema`, `MinTRLResultSchema`, and `DSRResultSchema`.
+- For correlated backtest cohorts, prefer `correlation_method="effective_rank"`
+  first, persist `n_trials_raw` and `n_trials_effective`, and only raise
+  `min_k_eff` above `1.0` when you want an explicit conservative floor.

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b19"
+__version__ = "0.1.0b20"
 
 # Sub-modules for advanced usage
 from . import (

--- a/src/ml4t/diagnostic/core/purging.py
+++ b/src/ml4t/diagnostic/core/purging.py
@@ -22,40 +22,6 @@ if TYPE_CHECKING:
     from ml4t.diagnostic.splitters.calendar import TradingCalendar
 
 
-_DATETIME_UNIT_TO_NS = {
-    "s": 1_000_000_000,
-    "ms": 1_000_000,
-    "us": 1_000,
-    "ns": 1,
-}
-
-
-def _searchsorted_timestamp(
-    timestamps: pd.DatetimeIndex,
-    timestamp: pd.Timestamp,
-    side: Literal["left", "right"],
-) -> np.intp:
-    """Search a DatetimeIndex using the index's native datetime unit.
-
-    pandas 3.x can back DatetimeIndex with microsecond resolution, while
-    Timestamp arithmetic still commonly produces nanosecond values. Converting
-    through the index unit avoids ``Cannot losslessly convert units`` errors
-    while preserving insertion semantics for left/right boundaries.
-    """
-    unit = cast(str, getattr(timestamps, "unit", "ns"))
-    ns_per_unit = _DATETIME_UNIT_TO_NS.get(unit)
-    if ns_per_unit is None:
-        raise ValueError(f"Unsupported datetime unit: {unit}")
-
-    timestamp_ns = int(timestamp.value)
-    if side == "left":
-        target_value = -(-timestamp_ns // ns_per_unit)
-    else:
-        target_value = timestamp_ns // ns_per_unit
-
-    return np.intp(np.searchsorted(timestamps.asi8, target_value, side=side))
-
-
 def _normalize_timezone_aware_inputs(
     timestamps: pd.DatetimeIndex,
     test_start: pd.Timestamp,
@@ -74,6 +40,21 @@ def _normalize_timezone_aware_inputs(
         test_start.tz_convert("UTC"),
         test_end.tz_convert("UTC"),
     )
+
+
+def _searchsorted_timestamp_ns(
+    timestamps: pd.DatetimeIndex,
+    value: pd.Timestamp,
+    *,
+    side: Literal["left", "right"] = "left",
+) -> int:
+    """Search timezone-aware timestamps using nanosecond integers.
+
+    Pandas 3.0 tightened unit conversion rules for DatetimeIndex.searchsorted().
+    Searching on normalized nanosecond integers avoids lossy unit-conversion
+    errors and also gives the type checker a plain numpy path.
+    """
+    return int(np.searchsorted(timestamps.as_unit("ns").asi8, value.value, side=side))
 
 
 def calculate_purge_indices(
@@ -427,8 +408,8 @@ def apply_purging_and_embargo(
     # Also remove test indices themselves
     if timestamps is not None:
         # Use searchsorted for more robust boundary handling
-        test_start_idx = _searchsorted_timestamp(timestamps, test_start, side="left")
-        test_end_idx = _searchsorted_timestamp(timestamps, test_end, side="left")
+        test_start_idx = _searchsorted_timestamp_ns(timestamps, test_start, side="left")
+        test_end_idx = _searchsorted_timestamp_ns(timestamps, test_end, side="left")
         test_arr = np.arange(test_start_idx, test_end_idx, dtype=np.intp)
     else:
         # When timestamps is None, test_start/test_end are integer indices

--- a/src/ml4t/diagnostic/evaluation/AGENTS.md
+++ b/src/ml4t/diagnostic/evaluation/AGENTS.md
@@ -15,7 +15,7 @@ This package holds the main research and validation workflows.
 
 | Directory | Purpose |
 |-----------|---------|
-| [stats/](stats/AGENTS.md) | DSR, RAS, FDR, HAC, PBO, MinTRL |
+| [stats/](stats/AGENTS.md) | DSR/PSR, correlation-adjusted K_eff, RAS, FDR, HAC, PBO, MinTRL |
 | [../metrics/](../metrics/AGENTS.md) | IC, importance, interactions, feature-outcome analysis |
 | [factor/](factor/AGENTS.md) | Returns-based factor modeling and attribution |
 | [trade_shap/](trade_shap/AGENTS.md) | Trade-level SHAP pipeline components |
@@ -25,3 +25,6 @@ This package holds the main research and validation workflows.
 - User-facing wrappers for Trade SHAP live in `trade_shap_diagnostics.py`.
 - Signal analysis has its own facade in `src/ml4t/diagnostic/signal/`.
 - The public docs for these workflows live under `docs/user-guide/` and `docs/methods/`.
+- DSR work now includes `effective_number_of_trials()` and
+  `deflated_sharpe_ratio(..., correlation_method=..., min_k_eff=...)` for
+  correlated strategy cohorts.

--- a/src/ml4t/diagnostic/evaluation/framework.py
+++ b/src/ml4t/diagnostic/evaluation/framework.py
@@ -784,6 +784,10 @@ class Evaluator:
                                 "expected_max_sharpe": dsr_result.expected_max_sharpe,
                                 "z_score": dsr_result.z_score,
                                 "is_significant": dsr_result.is_significant,
+                                "n_trials_raw": dsr_result.n_trials_raw,
+                                "n_trials_effective": dsr_result.n_trials_effective,
+                                "correlation_method": dsr_result.correlation_method,
+                                "min_k_eff": dsr_result.min_k_eff,
                             }
                         else:
                             continue

--- a/src/ml4t/diagnostic/evaluation/stats/AGENTS.md
+++ b/src/ml4t/diagnostic/evaluation/stats/AGENTS.md
@@ -5,6 +5,7 @@ Multiple-testing correction and robust inference for strategy evaluation.
 ## Main Modules
 
 - `deflated_sharpe_ratio.py` - PSR and DSR from returns or pre-computed statistics
+- `effective_trials.py` - correlation-adjusted K_eff estimators for DSR
 - `minimum_track_record.py` - MinTRL calculations
 - `backtest_overfitting.py` - Probability of Backtest Overfitting helpers
 - `rademacher_adjustment.py` - RAS adjustments
@@ -17,6 +18,7 @@ Multiple-testing correction and robust inference for strategy evaluation.
 
 - `deflated_sharpe_ratio`
 - `deflated_sharpe_ratio_from_statistics`
+- `effective_number_of_trials`
 - `compute_min_trl`
 - `compute_pbo`
 - `ras_sharpe_adjustment`
@@ -27,3 +29,9 @@ Multiple-testing correction and robust inference for strategy evaluation.
 
 - Public kurtosis inputs use Fisher/excess kurtosis (`normal = 0`)
 - `DSRResult`, `MinTRLResult`, and related result objects carry richer interpretation than raw scalars
+- `deflated_sharpe_ratio()` accepts either a sequence of return series or a 2D
+  return matrix for multi-strategy DSR.
+- For correlated strategy cohorts, prefer `correlation_method="effective_rank"`
+  before trying `marchenko_pastur` or `clustering`.
+- `min_k_eff` is a conservative floor on correlation-adjusted `K_eff`; default
+  `1.0` preserves estimator output without adding extra policy.

--- a/src/ml4t/diagnostic/evaluation/stats/__init__.py
+++ b/src/ml4t/diagnostic/evaluation/stats/__init__.py
@@ -29,6 +29,7 @@ The stats package is organized into focused modules:
 **Sharpe Ratio Analysis**:
 - moments.py: Return statistics (Sharpe, skewness, kurtosis, autocorr)
 - sharpe_inference.py: Variance estimation, expected max calculation
+- effective_trials.py: Correlation-adjusted K_eff estimators for DSR
 - minimum_track_record.py: Minimum Track Record Length
 - backtest_overfitting.py: Probability of Backtest Overfitting
 - deflated_sharpe_ratio.py: DSR/PSR orchestration layer (main entry points)
@@ -70,6 +71,11 @@ from ml4t.diagnostic.evaluation.stats.deflated_sharpe_ratio import (
     Frequency,
     deflated_sharpe_ratio,
     deflated_sharpe_ratio_from_statistics,
+)
+from ml4t.diagnostic.evaluation.stats.effective_trials import (
+    EffectiveTrialsMethod,
+    EffectiveTrialsResult,
+    effective_number_of_trials,
 )
 
 # =============================================================================
@@ -169,6 +175,9 @@ __all__ = [
     "Frequency",
     "deflated_sharpe_ratio",
     "deflated_sharpe_ratio_from_statistics",
+    "EffectiveTrialsMethod",
+    "EffectiveTrialsResult",
+    "effective_number_of_trials",
     # RAS
     "RASResult",
     "rademacher_complexity",

--- a/src/ml4t/diagnostic/evaluation/stats/deflated_sharpe_ratio.py
+++ b/src/ml4t/diagnostic/evaluation/stats/deflated_sharpe_ratio.py
@@ -32,6 +32,11 @@ from numpy.typing import ArrayLike
 from scipy.stats import norm
 
 from ml4t.diagnostic.evaluation.stats.backtest_overfitting import PBOResult, compute_pbo
+from ml4t.diagnostic.evaluation.stats.effective_trials import (
+    EffectiveTrialsMethod,
+    EffectiveTrialsResult,
+    effective_number_of_trials,
+)
 
 # Import from decomposed modules
 from ml4t.diagnostic.evaluation.stats.minimum_track_record import (
@@ -81,6 +86,17 @@ class DSRResult:
         Number of return observations (T).
     n_trials : int
         Number of strategies tested (K). K=1 means PSR, K>1 means DSR.
+    n_trials_raw : int
+        Raw number of tested strategies before any correlation adjustment.
+    n_trials_effective : float | None
+        Effective number of trials, K_eff, when a correlation-aware adjustment
+        is used. ``None`` means raw K was used.
+    correlation_method : str | None
+        Correlation-aware effective-trials estimator, if used.
+    min_k_eff : float
+        Minimum effective-trials floor applied to correlation-adjusted K_eff.
+        A value above 1.0 makes the multiple-testing correction more
+        conservative when the estimated K_eff collapses toward one.
     frequency : str
         Return frequency ("daily", "weekly", "monthly").
 
@@ -127,6 +143,10 @@ class DSRResult:
     # Sample information
     n_samples: int
     n_trials: int
+    n_trials_raw: int
+    n_trials_effective: float | None
+    correlation_method: str | None
+    min_k_eff: float
     frequency: str
     periods_per_year: int
 
@@ -155,10 +175,25 @@ class DSRResult:
             selection_note = ""
         else:
             test_type = f"Deflated Sharpe Ratio (DSR) - best of {self.n_trials} strategies"
-            selection_note = (
-                f"\n  Expected max from noise: {self.expected_max_sharpe:.4f}"
-                f"\n  Deflated Sharpe: {self.deflated_sharpe:.4f}"
-            )
+            selection_lines = [
+                f"  Expected max from noise: {self.expected_max_sharpe:.4f}",
+                f"  Deflated Sharpe: {self.deflated_sharpe:.4f}",
+            ]
+            if self.n_trials_effective is not None:
+                selection_lines.insert(0, f"  Raw trials: {self.n_trials_raw}")
+                selection_lines.insert(1, f"  Effective trials: {self.n_trials_effective:.2f}")
+                if self.min_k_eff > 1:
+                    selection_lines.insert(2, f"  Minimum K_eff floor: {self.min_k_eff:.2f}")
+            if self.correlation_method is not None:
+                selection_lines.insert(
+                    3
+                    if self.n_trials_effective is not None and self.min_k_eff > 1
+                    else 2
+                    if self.n_trials_effective is not None
+                    else 0,
+                    f"  Correlation adjustment: {self.correlation_method}",
+                )
+            selection_note = "\n" + "\n".join(selection_lines)
 
         significance = "Yes" if self.is_significant else "No"
         confidence_pct = self.confidence_level * 100
@@ -215,6 +250,10 @@ class DSRResult:
             "benchmark_sharpe": self.benchmark_sharpe,
             "n_samples": self.n_samples,
             "n_trials": self.n_trials,
+            "n_trials_raw": self.n_trials_raw,
+            "n_trials_effective": self.n_trials_effective,
+            "correlation_method": self.correlation_method,
+            "min_k_eff": self.min_k_eff,
             "frequency": self.frequency,
             "periods_per_year": self.periods_per_year,
             "skewness": self.skewness,
@@ -240,6 +279,9 @@ def deflated_sharpe_ratio(
     skewness: float | None = None,
     excess_kurtosis: float | None = None,
     autocorrelation: float | None = None,
+    effective_trials: float | None = None,
+    correlation_method: EffectiveTrialsMethod | None = None,
+    min_k_eff: float = 1.0,
 ) -> DSRResult:
     """Compute Deflated Sharpe Ratio (DSR) or Probabilistic Sharpe Ratio (PSR).
 
@@ -258,7 +300,8 @@ def deflated_sharpe_ratio(
     returns : array-like or Sequence[array-like]
         Strategy returns at the specified frequency.
         - Single array: Computes PSR (no multiple testing adjustment)
-        - Sequence of K arrays: Computes DSR for the best strategy
+        - Sequence of K arrays or a 2D return matrix: Computes DSR for the
+          best strategy
     frequency : {"daily", "weekly", "monthly"}, default "daily"
         Return frequency. Affects annualization for display.
     benchmark_sharpe : float, default 0.0
@@ -273,6 +316,26 @@ def deflated_sharpe_ratio(
         Override computed excess kurtosis (Fisher convention, normal=0).
     autocorrelation : float, optional
         Override computed autocorrelation.
+    effective_trials : float, optional
+        Correlation-adjusted effective number of trials, K_eff. When supplied,
+        it replaces the raw trial count in the False Strategy Theorem.
+    correlation_method : {"effective_rank", "marchenko_pastur", "clustering"}, optional
+        Compute K_eff from the strategy return matrix using the selected
+        estimator. Only valid when multiple strategies are supplied.
+    min_k_eff : float, default 1.0
+        Lower bound applied to correlation-adjusted ``K_eff`` before computing
+        the expected-maximum Sharpe term. This does not change raw-K DSR calls
+        and does not turn a single-strategy PSR call into a multiple-testing
+        problem. Values above 1.0 add a conservative floor when the estimated
+        effective trial count collapses toward one.
+
+    Notes
+    -----
+    For multiple-strategy inputs, the library selects the leader strategy by
+    the highest native-frequency Sharpe ratio. The reported skewness, excess
+    kurtosis, and autocorrelation in the resulting `DSRResult` are computed
+    from that leader series. The cross-sectional variance and expected-maximum
+    correction are computed from the full candidate cohort.
 
     Returns
     -------
@@ -296,23 +359,52 @@ def deflated_sharpe_ratio(
     ----------
     Lopez de Prado et al. (2025). "How to Use the Sharpe Ratio."
     """
+    if effective_trials is not None and effective_trials < 1:
+        raise ValueError("effective_trials must be >= 1")
+    if effective_trials is not None and correlation_method is not None:
+        raise ValueError("effective_trials and correlation_method are mutually exclusive")
+    if min_k_eff < 1:
+        raise ValueError("min_k_eff must be >= 1")
+
     # Resolve periods per year
     if periods_per_year is None:
         periods_per_year = DEFAULT_PERIODS_PER_YEAR[frequency]
 
     annualization_factor = np.sqrt(periods_per_year)
 
-    # Detect multiple strategies
-    is_multiple = (
+    returns_array = (
+        np.asarray(returns, dtype=float) if not isinstance(returns, list | tuple) else None
+    )
+    is_matrix_input = (
+        returns_array is not None and returns_array.ndim == 2 and returns_array.shape[1] > 1
+    )
+    is_multiple = is_matrix_input or (
         isinstance(returns, list | tuple)
         and len(returns) > 1
         and not isinstance(returns[0], int | float)
     )
 
+    effective_trials_result: EffectiveTrialsResult | None = None
+
     if is_multiple:
         # Multiple strategies - DSR
-        returns_seq = list(returns)  # type: ignore[arg-type]
-        n_trials = len(returns_seq)
+        if is_matrix_input:
+            assert returns_array is not None
+            returns_seq = [returns_array[:, i] for i in range(returns_array.shape[1])]
+            returns_matrix = returns_array
+        else:
+            returns_seq = list(returns)  # type: ignore[arg-type]
+            lengths = {len(np.asarray(ret).flatten()) for ret in returns_seq}
+            if correlation_method is not None and len(lengths) != 1:
+                raise ValueError(
+                    "correlation_method requires strategies with equal-length return histories"
+                )
+            returns_matrix = (
+                np.column_stack([np.asarray(ret, dtype=float).flatten() for ret in returns_seq])
+                if len(lengths) == 1
+                else None
+            )
+        n_trials_raw = len(returns_seq)
 
         # Compute Sharpe ratio for each strategy
         sharpe_ratios = []
@@ -332,11 +424,21 @@ def deflated_sharpe_ratio(
         )
 
         # Cross-sectional variance
-        variance_trials = float(np.var(sharpe_ratios, ddof=1)) if n_trials > 1 else 0.0
+        variance_trials = float(np.var(sharpe_ratios, ddof=1)) if n_trials_raw > 1 else 0.0
+
+        if correlation_method is not None:
+            if returns_matrix is None:
+                raise ValueError("correlation_method requires a 2D strategy return matrix")
+            effective_trials_result = effective_number_of_trials(
+                returns_matrix,
+                method=correlation_method,
+            )
+            if effective_trials_result.variance_trials is not None:
+                variance_trials = effective_trials_result.variance_trials
 
     else:
         # Single strategy - PSR
-        n_trials = 1
+        n_trials_raw = 1
         variance_trials = 0.0
 
         if isinstance(returns, list | tuple) and len(returns) == 1:
@@ -347,6 +449,13 @@ def deflated_sharpe_ratio(
         observed_sharpe, comp_skew, comp_kurt, comp_rho, n_samples = compute_return_statistics(
             ret_arr
         )
+        if correlation_method is not None:
+            raise ValueError("correlation_method requires multiple strategies")
+        if effective_trials is not None and effective_trials > 1:
+            raise ValueError(
+                "effective_trials > 1 requires multiple strategies or "
+                "deflated_sharpe_ratio_from_statistics()"
+            )
 
     # Use provided statistics or computed ones
     skew = skewness if skewness is not None else comp_skew
@@ -356,8 +465,15 @@ def deflated_sharpe_ratio(
         kurt = comp_kurt
     rho = autocorrelation if autocorrelation is not None else comp_rho
 
+    effective_k = (
+        effective_trials_result.k_eff if effective_trials_result is not None else effective_trials
+    )
+    if effective_k is not None and n_trials_raw > 1:
+        effective_k = max(float(effective_k), float(min_k_eff))
+    trials_for_adjustment = effective_k if effective_k is not None else float(n_trials_raw)
+
     # Expected max Sharpe (multiple testing adjustment)
-    expected_max = compute_expected_max_sharpe(n_trials, variance_trials)
+    expected_max = compute_expected_max_sharpe(trials_for_adjustment, variance_trials)
     adjusted_threshold = benchmark_sharpe + expected_max
 
     # Variance of Sharpe estimator
@@ -367,7 +483,7 @@ def deflated_sharpe_ratio(
         skewness=skew,
         kurtosis=kurt,
         autocorrelation=rho,
-        n_trials=n_trials,
+        n_trials=trials_for_adjustment,
     )
     std_sr = np.sqrt(variance_sr)
 
@@ -407,7 +523,13 @@ def deflated_sharpe_ratio(
         sharpe_ratio_annualized=float(sharpe_annualized),
         benchmark_sharpe=benchmark_sharpe,
         n_samples=n_samples,
-        n_trials=n_trials,
+        n_trials=n_trials_raw,
+        n_trials_raw=n_trials_raw,
+        n_trials_effective=float(effective_k) if effective_k is not None else None,
+        correlation_method=(
+            effective_trials_result.method if effective_trials_result is not None else None
+        ),
+        min_k_eff=float(min_k_eff),
         frequency=frequency,
         periods_per_year=periods_per_year,
         skewness=float(skew),
@@ -435,6 +557,10 @@ def deflated_sharpe_ratio_from_statistics(
     confidence_level: float = 0.95,
     frequency: Frequency = "daily",
     periods_per_year: int | None = None,
+    *,
+    effective_trials: float | None = None,
+    correlation_method: EffectiveTrialsMethod | None = None,
+    min_k_eff: float = 1.0,
 ) -> DSRResult:
     """Compute DSR/PSR from pre-computed statistics.
 
@@ -465,6 +591,13 @@ def deflated_sharpe_ratio_from_statistics(
         Return frequency.
     periods_per_year : int, optional
         Periods per year.
+    effective_trials : float, optional
+        Correlation-adjusted effective number of trials, K_eff.
+    correlation_method : {"effective_rank", "marchenko_pastur", "clustering"}, optional
+        Metadata describing how ``effective_trials`` was estimated.
+    min_k_eff : float, default 1.0
+        Lower bound applied to ``effective_trials`` before computing the
+        expected-maximum Sharpe term. Ignored when raw ``n_trials`` is used.
 
     Returns
     -------
@@ -480,6 +613,10 @@ def deflated_sharpe_ratio_from_statistics(
         raise ValueError("variance_trials must be positive when n_trials > 1")
     if abs(autocorrelation) >= 1:
         raise ValueError("autocorrelation must be in (-1, 1)")
+    if effective_trials is not None and effective_trials < 1:
+        raise ValueError("effective_trials must be >= 1")
+    if min_k_eff < 1:
+        raise ValueError("min_k_eff must be >= 1")
 
     kurtosis = excess_kurtosis + 3.0
 
@@ -487,9 +624,15 @@ def deflated_sharpe_ratio_from_statistics(
         periods_per_year = DEFAULT_PERIODS_PER_YEAR[frequency]
 
     annualization_factor = np.sqrt(periods_per_year)
+    effective_k = (
+        max(float(effective_trials), float(min_k_eff))
+        if effective_trials is not None and n_trials > 1
+        else effective_trials
+    )
+    trials_for_adjustment = effective_k if effective_k is not None else float(n_trials)
 
     # Expected max Sharpe
-    expected_max = compute_expected_max_sharpe(n_trials, variance_trials)
+    expected_max = compute_expected_max_sharpe(trials_for_adjustment, variance_trials)
     adjusted_threshold = benchmark_sharpe + expected_max
 
     # Variance
@@ -499,7 +642,7 @@ def deflated_sharpe_ratio_from_statistics(
         skewness=skewness,
         kurtosis=kurtosis,
         autocorrelation=autocorrelation,
-        n_trials=n_trials,
+        n_trials=trials_for_adjustment,
     )
     std_sr = np.sqrt(variance_sr)
 
@@ -538,6 +681,10 @@ def deflated_sharpe_ratio_from_statistics(
         benchmark_sharpe=benchmark_sharpe,
         n_samples=n_samples,
         n_trials=n_trials,
+        n_trials_raw=n_trials,
+        n_trials_effective=float(effective_k) if effective_k is not None else None,
+        correlation_method=correlation_method,
+        min_k_eff=float(min_k_eff),
         frequency=frequency,
         periods_per_year=periods_per_year,
         skewness=float(skewness),
@@ -569,9 +716,12 @@ _compute_min_trl = _compute_min_trl_core
 __all__ = [
     # Result classes
     "DSRResult",
+    "EffectiveTrialsMethod",
+    "EffectiveTrialsResult",
     # Main functions
     "deflated_sharpe_ratio",
     "deflated_sharpe_ratio_from_statistics",
+    "effective_number_of_trials",
     # Re-exports from other modules (for backward compat)
     "MinTRLResult",
     "PBOResult",

--- a/src/ml4t/diagnostic/evaluation/stats/effective_trials.py
+++ b/src/ml4t/diagnostic/evaluation/stats/effective_trials.py
@@ -1,0 +1,358 @@
+"""Effective number of trials for correlation-adjusted Sharpe inference.
+
+This module implements correlation-aware estimators for the effective number of
+independent strategy trials, K_eff.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from ml4t.diagnostic.evaluation.stats.moments import compute_return_statistics
+
+EffectiveTrialsMethod = Literal["effective_rank", "marchenko_pastur", "clustering"]
+
+_EIGENVALUE_TOL = 1e-12
+_CLUSTERING_MAX_CANDIDATES = 40
+
+
+@dataclass
+class EffectiveTrialsResult:
+    """Result of effective-trials estimation."""
+
+    k_eff: float
+    method: str
+    eigenvalues: np.ndarray
+    n_clusters: int | None = None
+    mp_upper_bound: float | None = None
+    variance_trials: float | None = None
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce_return_matrix(returns: ArrayLike) -> tuple[np.ndarray, int]:
+    """Validate and clean a strategy return matrix."""
+    matrix = np.asarray(returns, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError("returns must be a 2D array of shape (n_periods, n_strategies)")
+
+    n_periods, n_strategies = matrix.shape
+    if n_periods < 2:
+        raise ValueError("returns must contain at least two periods")
+    if n_strategies < 1:
+        raise ValueError("returns must contain at least one strategy")
+
+    finite_rows = np.all(np.isfinite(matrix), axis=1)
+    dropped_rows = int((~finite_rows).sum())
+    clean = matrix[finite_rows]
+    if clean.shape[0] < 2:
+        raise ValueError("returns must contain at least two fully finite observations")
+
+    std = np.std(clean, axis=0, ddof=1)
+    if np.any(std <= _EIGENVALUE_TOL):
+        raise ValueError("returns contain a constant strategy; correlation matrix is undefined")
+
+    return clean, dropped_rows
+
+
+def _effective_rank(eigenvalues: np.ndarray) -> float:
+    """Compute effective rank from non-negative eigenvalues."""
+    positive = eigenvalues[eigenvalues > _EIGENVALUE_TOL]
+    if positive.size == 0:
+        return 1.0
+
+    weights = positive / positive.sum()
+    entropy = -np.sum(weights * np.log(weights))
+    return float(np.exp(entropy))
+
+
+def _marchenko_pastur_upper_bound(n_periods: int, n_strategies: int) -> float:
+    """Upper edge of the Marchenko-Pastur bulk for a correlation matrix."""
+    aspect_ratio = n_strategies / n_periods
+    return float((1.0 + np.sqrt(aspect_ratio)) ** 2)
+
+
+def _marchenko_pastur_k_eff(
+    eigenvalues: np.ndarray, n_periods: int
+) -> tuple[int, float, list[dict[str, float]]]:
+    """Iteratively count signal eigenvalues above the M-P upper bound."""
+    remaining = eigenvalues.copy()
+    total_signal = 0
+    iterations: list[dict[str, float]] = []
+    while remaining.size > 0:
+        upper_bound = _marchenko_pastur_upper_bound(n_periods, remaining.size)
+        signal_count = int(np.sum(remaining > upper_bound + _EIGENVALUE_TOL))
+        iterations.append(
+            {
+                "n_remaining": float(remaining.size),
+                "mp_upper_bound": upper_bound,
+                "n_signal": float(signal_count),
+            }
+        )
+        if signal_count == 0:
+            return total_signal, upper_bound, iterations
+        total_signal += signal_count
+        remaining = remaining[signal_count:]
+
+    return total_signal, _marchenko_pastur_upper_bound(n_periods, 1), iterations
+
+
+def _minimum_variance_weights(returns: np.ndarray) -> np.ndarray:
+    """Compute minimum-variance portfolio weights for a strategy cluster."""
+    n_strategies = returns.shape[1]
+    if n_strategies == 1:
+        return np.array([1.0], dtype=float)
+
+    cov = np.cov(returns, rowvar=False, ddof=1)
+    cov = np.atleast_2d(cov)
+    inv_cov = np.linalg.pinv(cov)
+    ones = np.ones(n_strategies, dtype=float)
+    raw = inv_cov @ ones
+    denom = float(ones @ raw)
+    if abs(denom) <= _EIGENVALUE_TOL:
+        return np.full(n_strategies, 1.0 / n_strategies, dtype=float)
+    weights = raw / denom
+    if not np.all(np.isfinite(weights)):
+        return np.full(n_strategies, 1.0 / n_strategies, dtype=float)
+    return weights
+
+
+def _cluster_trial_returns(
+    returns: np.ndarray,
+    labels: np.ndarray,
+) -> tuple[list[np.ndarray], list[float], list[int], list[list[float]]]:
+    """Aggregate strategy clusters into representative return series."""
+    cluster_returns: list[np.ndarray] = []
+    cluster_sharpes: list[float] = []
+    cluster_sizes: list[int] = []
+    cluster_weights: list[list[float]] = []
+
+    for cluster_id in sorted(np.unique(labels)):
+        cluster_slice = returns[:, labels == cluster_id]
+        weights = _minimum_variance_weights(cluster_slice)
+        agg_returns = cluster_slice @ weights
+        sharpe, _, _, _, _ = compute_return_statistics(agg_returns)
+        cluster_returns.append(agg_returns)
+        cluster_sharpes.append(float(sharpe))
+        cluster_sizes.append(int(cluster_slice.shape[1]))
+        cluster_weights.append(weights.tolist())
+
+    return cluster_returns, cluster_sharpes, cluster_sizes, cluster_weights
+
+
+def _silhouette_t_stat(distance_matrix: np.ndarray, labels: np.ndarray) -> float:
+    """Compute silhouette t-statistic for a clustering."""
+    from sklearn.metrics import silhouette_samples
+
+    unique_labels = np.unique(labels)
+    if unique_labels.size < 2 or unique_labels.size >= len(labels):
+        return float("-inf")
+
+    values = silhouette_samples(distance_matrix, labels, metric="precomputed")
+    if values.size < 2:
+        return float("-inf")
+    mean_val = float(np.mean(values))
+    std_val = float(np.std(values, ddof=1))
+    if std_val <= _EIGENVALUE_TOL:
+        return float("inf") if mean_val > 0 else float("-inf")
+    return mean_val / (std_val / np.sqrt(values.size))
+
+
+def _clustering_k_eff(
+    returns: np.ndarray,
+    corr: np.ndarray,
+) -> tuple[int, float, dict[str, Any]]:
+    """Estimate K_eff by clustering strategies with silhouette selection."""
+    from scipy.cluster.hierarchy import fcluster, linkage
+    from scipy.spatial.distance import squareform
+    from sklearn.metrics import silhouette_score
+
+    n_strategies = returns.shape[1]
+    if n_strategies == 1:
+        cluster_returns, cluster_sharpes, cluster_sizes, cluster_weights = _cluster_trial_returns(
+            returns,
+            np.zeros(1, dtype=int),
+        )
+        return (
+            1,
+            0.0,
+            {
+                "labels": [0],
+                "cluster_returns": cluster_returns,
+                "cluster_sharpes": cluster_sharpes,
+                "cluster_sizes": cluster_sizes,
+                "cluster_weights": cluster_weights,
+                "silhouette_score": None,
+                "silhouette_t_stat": None,
+                "candidate_scores": [],
+            },
+        )
+
+    if n_strategies == 2:
+        labels = np.array([0, 1], dtype=int)
+        cluster_returns, cluster_sharpes, cluster_sizes, cluster_weights = _cluster_trial_returns(
+            returns, labels
+        )
+        variance = float(np.var(cluster_sharpes, ddof=1))
+        return (
+            2,
+            variance,
+            {
+                "labels": labels.tolist(),
+                "cluster_returns": cluster_returns,
+                "cluster_sharpes": cluster_sharpes,
+                "cluster_sizes": cluster_sizes,
+                "cluster_weights": cluster_weights,
+                "silhouette_score": None,
+                "silhouette_t_stat": None,
+                "candidate_scores": [],
+            },
+        )
+
+    distance = np.sqrt(np.clip(0.5 * (1.0 - corr), 0.0, None))
+    np.fill_diagonal(distance, 0.0)
+    condensed = squareform(distance, checks=False)
+    linkage_matrix = linkage(condensed, method="average")
+
+    max_candidates = min(n_strategies - 1, _CLUSTERING_MAX_CANDIDATES)
+    best_labels: np.ndarray | None = None
+    best_score = float("-inf")
+    candidate_scores: list[dict[str, float]] = []
+
+    for n_clusters in range(2, max_candidates + 1):
+        labels = fcluster(linkage_matrix, t=n_clusters, criterion="maxclust") - 1
+        if np.unique(labels).size < 2:
+            continue
+        t_stat = _silhouette_t_stat(distance, labels)
+        if not np.isfinite(t_stat):
+            continue
+        candidate_scores.append({"n_clusters": float(n_clusters), "silhouette_t": t_stat})
+        if t_stat > best_score:
+            best_score = t_stat
+            best_labels = labels
+
+    if best_labels is None:
+        best_labels = np.arange(n_strategies, dtype=int)
+        best_score = float("-inf")
+
+    cluster_returns, cluster_sharpes, cluster_sizes, cluster_weights = _cluster_trial_returns(
+        returns,
+        best_labels,
+    )
+    variance = float(np.var(cluster_sharpes, ddof=1)) if len(cluster_sharpes) > 1 else 0.0
+    silhouette = None
+    if np.unique(best_labels).size >= 2 and np.unique(best_labels).size < len(best_labels):
+        silhouette = float(silhouette_score(distance, best_labels, metric="precomputed"))
+
+    return (
+        int(np.unique(best_labels).size),
+        variance,
+        {
+            "labels": best_labels.tolist(),
+            "cluster_returns": cluster_returns,
+            "cluster_sharpes": cluster_sharpes,
+            "cluster_sizes": cluster_sizes,
+            "cluster_weights": cluster_weights,
+            "silhouette_score": silhouette,
+            "silhouette_t_stat": None if not np.isfinite(best_score) else float(best_score),
+            "candidate_scores": candidate_scores,
+        },
+    )
+
+
+def effective_number_of_trials(
+    returns: ArrayLike,
+    method: EffectiveTrialsMethod = "effective_rank",
+    *,
+    random_state: int | None = None,
+) -> EffectiveTrialsResult:
+    """Estimate the effective number of trials, K_eff, from strategy returns.
+
+    Parameters
+    ----------
+    returns : array-like
+        Strategy return matrix of shape ``(n_periods, n_strategies)``.
+    method : {"effective_rank", "marchenko_pastur", "clustering"}, default "effective_rank"
+        Estimator for K_eff.
+        - ``effective_rank``: eigenvalue-entropy effective rank
+        - ``marchenko_pastur``: iterative denoising variant that repeatedly
+          removes eigenvalues above the Marchenko-Pastur upper edge
+        - ``clustering``: silhouette-selected cluster count on correlation distance
+    random_state : int, optional
+        Reserved for future estimators that require randomness.
+    """
+    del random_state  # reserved for future estimators
+
+    clean, dropped_rows = _coerce_return_matrix(returns)
+    corr = np.corrcoef(clean, rowvar=False)
+    eigenvalues = np.linalg.eigvalsh(corr)
+    eigenvalues = np.sort(np.clip(eigenvalues.real, 0.0, None))[::-1]
+
+    positive = eigenvalues[eigenvalues > _EIGENVALUE_TOL]
+    entropy = 0.0
+    if positive.size > 0:
+        weights = positive / positive.sum()
+        entropy = float(-np.sum(weights * np.log(weights)))
+
+    base_diagnostics = {
+        "n_periods": int(clean.shape[0]),
+        "n_strategies": int(clean.shape[1]),
+        "dropped_rows": dropped_rows,
+        "effective_rank_entropy": entropy,
+    }
+
+    if method == "effective_rank":
+        k_eff = _effective_rank(eigenvalues)
+        k_eff = float(np.clip(k_eff, 1.0, clean.shape[1]))
+        return EffectiveTrialsResult(
+            k_eff=k_eff,
+            method=method,
+            eigenvalues=eigenvalues,
+            diagnostics=base_diagnostics,
+        )
+
+    if method == "marchenko_pastur":
+        k_eff, upper_bound, iterations = _marchenko_pastur_k_eff(eigenvalues, clean.shape[0])
+        k_eff = float(np.clip(k_eff, 1, clean.shape[1]))
+        return EffectiveTrialsResult(
+            k_eff=k_eff,
+            method=method,
+            eigenvalues=eigenvalues,
+            mp_upper_bound=upper_bound,
+            diagnostics={
+                **base_diagnostics,
+                "mp_iterations": iterations,
+            },
+        )
+
+    if method == "clustering":
+        k_eff, variance, clustering = _clustering_k_eff(clean, corr)
+        return EffectiveTrialsResult(
+            k_eff=float(np.clip(k_eff, 1, clean.shape[1])),
+            method=method,
+            eigenvalues=eigenvalues,
+            n_clusters=int(k_eff),
+            variance_trials=variance,
+            diagnostics={
+                **base_diagnostics,
+                "cluster_labels": clustering["labels"],
+                "cluster_sizes": clustering["cluster_sizes"],
+                "cluster_weights": clustering["cluster_weights"],
+                "cluster_sharpes": clustering["cluster_sharpes"],
+                "silhouette_score": clustering["silhouette_score"],
+                "silhouette_t_stat": clustering["silhouette_t_stat"],
+                "candidate_scores": clustering["candidate_scores"],
+            },
+        )
+
+    raise ValueError(f"Unsupported method: {method}")
+
+
+__all__ = [
+    "EffectiveTrialsMethod",
+    "EffectiveTrialsResult",
+    "effective_number_of_trials",
+]

--- a/src/ml4t/diagnostic/evaluation/stats/sharpe_inference.py
+++ b/src/ml4t/diagnostic/evaluation/stats/sharpe_inference.py
@@ -109,7 +109,7 @@ def probabilistic_sharpe_ratio(
     return psr
 
 
-def get_variance_rescaling_factor(k: int) -> float:
+def get_variance_rescaling_factor(k: float) -> float:
     """Get variance rescaling factor √V[max{X_k}] for K trials.
 
     Source: López de Prado et al. (2025), Exhibit 3, page 13.
@@ -124,8 +124,12 @@ def get_variance_rescaling_factor(k: int) -> float:
     float
         Rescaling factor (uses linear interpolation for unlisted values)
     """
-    if k in VARIANCE_RESCALING_FACTORS:
-        return VARIANCE_RESCALING_FACTORS[k]
+    if k <= 1:
+        return VARIANCE_RESCALING_FACTORS[1]
+
+    k_int = int(round(k))
+    if abs(k - k_int) < 1e-12 and k_int in VARIANCE_RESCALING_FACTORS:
+        return VARIANCE_RESCALING_FACTORS[k_int]
 
     keys = sorted(VARIANCE_RESCALING_FACTORS.keys())
     if k < keys[0]:
@@ -149,7 +153,7 @@ def compute_sharpe_variance(
     skewness: float,
     kurtosis: float,
     autocorrelation: float,
-    n_trials: int = 1,
+    n_trials: float = 1,
 ) -> float:
     """Compute variance of Sharpe ratio estimator.
 
@@ -231,7 +235,7 @@ def compute_sharpe_variance(
     return max(variance, 0.0)  # Ensure non-negative
 
 
-def compute_expected_max_sharpe(n_trials: int, variance_trials: float) -> float:
+def compute_expected_max_sharpe(n_trials: float, variance_trials: float) -> float:
     """Compute expected maximum Sharpe ratio under null hypothesis.
 
     .. math::
@@ -243,8 +247,8 @@ def compute_expected_max_sharpe(n_trials: int, variance_trials: float) -> float:
 
     Parameters
     ----------
-    n_trials : int
-        Number of strategies tested (K)
+    n_trials : float
+        Number of strategies tested (K or K_eff)
     variance_trials : float
         Cross-sectional variance of Sharpe ratios: Var[{SR_1, ..., SR_K}]
 

--- a/src/ml4t/diagnostic/metrics/importance_classical.py
+++ b/src/ml4t/diagnostic/metrics/importance_classical.py
@@ -329,17 +329,13 @@ def compute_mdi_importance(
             feature_names = model.feature_name_
         elif hasattr(model, "get_booster") and hasattr(model.get_booster(), "feature_names"):
             # XGBoost
-            booster_feature_names = model.get_booster().feature_names
-            if booster_feature_names is not None:
-                feature_names = list(booster_feature_names)
-            elif hasattr(model, "feature_names_in_"):
+            feature_names = model.get_booster().feature_names
+            if feature_names is None and hasattr(model, "feature_names_in_"):
                 feature_names = list(model.feature_names_in_)
-            else:
-                feature_names = [f"feature_{i}" for i in range(len(importances))]
         elif hasattr(model, "feature_names_in_"):
             # sklearn
             feature_names = list(model.feature_names_in_)
-        else:
+        if feature_names is None:
             # Fallback to numeric names
             feature_names = [f"feature_{i}" for i in range(len(importances))]
     else:

--- a/src/ml4t/diagnostic/results/sharpe_results.py
+++ b/src/ml4t/diagnostic/results/sharpe_results.py
@@ -196,6 +196,25 @@ class DSRResultSchema(BaseResult):
     is_significant: bool = Field(..., description="Is significant at alpha")
 
     n_trials: int = Field(..., gt=0, description="Number of trials tested")
+    n_trials_raw: int | None = Field(
+        default=None,
+        gt=0,
+        description="Raw number of tested strategies before correlation adjustment",
+    )
+    n_trials_effective: float | None = Field(
+        default=None,
+        ge=1.0,
+        description="Effective number of trials after correlation adjustment",
+    )
+    correlation_method: str | None = Field(
+        default=None,
+        description="Correlation-aware estimator used for effective trials",
+    )
+    min_k_eff: float = Field(
+        default=1.0,
+        ge=1.0,
+        description="Minimum effective-trials floor used for correlation-adjusted DSR",
+    )
     variance_trials: float = Field(..., ge=0.0, description="Variance of Sharpe across trials")
     alpha: float = Field(default=0.05, description="Significance level")
 
@@ -211,6 +230,10 @@ class DSRResultSchema(BaseResult):
             "adjusted_pvalue": [self.adjusted_pvalue],
             "is_significant": [self.is_significant],
             "n_trials": [self.n_trials],
+            "n_trials_raw": [self.n_trials_raw],
+            "n_trials_effective": [self.n_trials_effective],
+            "correlation_method": [self.correlation_method],
+            "min_k_eff": [self.min_k_eff],
             "variance_trials": [self.variance_trials],
             "alpha": [self.alpha],
         }
@@ -224,6 +247,14 @@ class DSRResultSchema(BaseResult):
         lines.append(f"Adjusted p-value: {self.adjusted_pvalue:.4f}")
         lines.append("")
         lines.append(f"Number of trials: {self.n_trials}")
+        if self.n_trials_raw is not None:
+            lines.append(f"Raw trials: {self.n_trials_raw}")
+        if self.n_trials_effective is not None:
+            lines.append(f"Effective trials: {self.n_trials_effective:.2f}")
+        if self.correlation_method is not None:
+            lines.append(f"Correlation adjustment: {self.correlation_method}")
+        if self.n_trials_effective is not None and self.min_k_eff > 1:
+            lines.append(f"Minimum K_eff floor: {self.min_k_eff:.2f}")
         lines.append(f"Trial variance: {self.variance_trials:.4f}")
         lines.append(f"Significance level: {self.alpha}")
         lines.append("")

--- a/src/ml4t/diagnostic/splitters/calendar.py
+++ b/src/ml4t/diagnostic/splitters/calendar.py
@@ -421,15 +421,21 @@ class TradingCalendar:
         counts samples in each complete block.
         """
         ts_naive = timestamps.tz_localize(None) if timestamps.tz is not None else timestamps
+        day_ns = 24 * 60 * 60 * 1_000_000_000
+        day_keys = ts_naive.normalize().as_unit("ns").asi8 // day_ns
 
-        # Period ordinals are stable across pandas datetime storage units,
-        # including pandas 3.x microsecond-backed timestamps.
+        # Group by calendar period (atomic unit) with integer keys to avoid
+        # expensive Period conversions and timezone warnings.
+        period_keys: np.ndarray
         if freq == "D":
-            period_keys = ts_naive.to_period("D").asi8
+            period_keys = day_keys
         elif freq == "W":
-            period_keys = ts_naive.to_period("W-SUN").asi8
+            weekday = ts_naive.weekday.to_numpy(dtype=np.int64, copy=False)
+            period_keys = day_keys - weekday
         elif freq == "M":
-            period_keys = ts_naive.to_period("M").asi8
+            year = ts_naive.year.to_numpy(dtype=np.int64, copy=False)
+            month = ts_naive.month.to_numpy(dtype=np.int64, copy=False)
+            period_keys = year * 12 + (month - 1)
         else:
             raise ValueError(f"Unsupported frequency: {freq}")
 

--- a/src/ml4t/diagnostic/splitters/walk_forward.py
+++ b/src/ml4t/diagnostic/splitters/walk_forward.py
@@ -21,7 +21,10 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
-from ml4t.diagnostic.core.purging import _searchsorted_timestamp, apply_purging_and_embargo
+from ml4t.diagnostic.core.purging import (
+    _searchsorted_timestamp_ns,
+    apply_purging_and_embargo,
+)
 from ml4t.diagnostic.splitters.base import BaseSplitter
 from ml4t.diagnostic.splitters.calendar import (
     TradingCalendar,
@@ -538,13 +541,13 @@ class WalkForwardCV(BaseSplitter):
 
             test_start_date = self.config.test_start
             test_start_ts = pd.Timestamp(test_start_date, tz=timestamps.tz)
-            test_start_idx = int(_searchsorted_timestamp(timestamps, test_start_ts, side="left"))
+            test_start_idx = _searchsorted_timestamp_ns(timestamps, test_start_ts, side="left")
 
             if self.config.test_end is not None:
                 test_end_date = self.config.test_end
                 test_end_ts = pd.Timestamp(test_end_date, tz=timestamps.tz)
                 # Find the index of the first timestamp >= test_end
-                test_end_idx = int(_searchsorted_timestamp(timestamps, test_end_ts, side="right"))
+                test_end_idx = _searchsorted_timestamp_ns(timestamps, test_end_ts, side="right")
             else:
                 # Default: end of data
                 test_end_idx = n_samples
@@ -559,8 +562,10 @@ class WalkForwardCV(BaseSplitter):
                     test_start_ts = self.calendar.previous_trading_day(
                         end_timestamp, n=self.config.test_period
                     )
-                    test_start_idx = int(
-                        _searchsorted_timestamp(timestamps, test_start_ts, side="left")
+                    test_start_idx = _searchsorted_timestamp_ns(
+                        timestamps,
+                        test_start_ts,
+                        side="left",
                     )
                 else:
                     # Sample count interpretation
@@ -575,15 +580,13 @@ class WalkForwardCV(BaseSplitter):
                 time_delta = pd.Timedelta(self.config.test_period)
                 end_timestamp = timestamps[-1]
                 test_start_ts = end_timestamp - time_delta
-                test_start_idx = int(
-                    _searchsorted_timestamp(timestamps, test_start_ts, side="left")
-                )
+                test_start_idx = _searchsorted_timestamp_ns(timestamps, test_start_ts, side="left")
 
             # test_end is always end of data for test_period mode
             if self.config.test_end is not None and timestamps is not None:
                 test_end_date = self.config.test_end
                 test_end_ts = pd.Timestamp(test_end_date, tz=timestamps.tz)
-                test_end_idx = int(_searchsorted_timestamp(timestamps, test_end_ts, side="right"))
+                test_end_idx = _searchsorted_timestamp_ns(timestamps, test_end_ts, side="right")
             else:
                 test_end_idx = n_samples
         else:

--- a/tests/test_evaluation/test_stats.py
+++ b/tests/test_evaluation/test_stats.py
@@ -14,6 +14,7 @@ from ml4t.diagnostic.evaluation.stats import (
     DSRResult,
     benjamini_hochberg_fdr,
     deflated_sharpe_ratio_from_statistics,
+    effective_number_of_trials,
     holm_bonferroni,
     rademacher_complexity,
     ras_ic_adjustment,
@@ -115,6 +116,120 @@ class TestDeflatedSharpeRatio:
 
         # More trials should lead to lower probability (more deflation)
         assert result_100.probability < result_10.probability
+
+    def test_dsr_effective_trials_override_reduces_deflation(self):
+        """Test correlation-adjusted K_eff lowers deflation versus raw K."""
+        result_raw = deflated_sharpe_ratio_from_statistics(
+            observed_sharpe=2.0,
+            n_trials=100,
+            variance_trials=0.5,
+            n_samples=252,
+        )
+        result_eff = deflated_sharpe_ratio_from_statistics(
+            observed_sharpe=2.0,
+            n_trials=100,
+            effective_trials=10.0,
+            variance_trials=0.5,
+            n_samples=252,
+            correlation_method="effective_rank",
+        )
+
+        assert result_eff.n_trials_raw == 100
+        assert result_eff.n_trials_effective == pytest.approx(10.0)
+        assert result_eff.correlation_method == "effective_rank"
+        assert result_eff.expected_max_sharpe < result_raw.expected_max_sharpe
+        assert result_eff.probability > result_raw.probability
+
+    def test_dsr_min_k_eff_applies_floor_to_effective_trials(self):
+        """A minimum K_eff floor should make correlation-adjusted DSR more conservative."""
+        result_unfloored = deflated_sharpe_ratio_from_statistics(
+            observed_sharpe=2.0,
+            n_trials=100,
+            effective_trials=1.25,
+            variance_trials=0.5,
+            n_samples=252,
+            correlation_method="effective_rank",
+        )
+        result_floored = deflated_sharpe_ratio_from_statistics(
+            observed_sharpe=2.0,
+            n_trials=100,
+            effective_trials=1.25,
+            variance_trials=0.5,
+            n_samples=252,
+            correlation_method="effective_rank",
+            min_k_eff=2.0,
+        )
+
+        assert result_unfloored.n_trials_effective == pytest.approx(1.25)
+        assert result_floored.n_trials_effective == pytest.approx(2.0)
+        assert result_floored.min_k_eff == pytest.approx(2.0)
+        assert result_floored.expected_max_sharpe > result_unfloored.expected_max_sharpe
+        assert result_floored.deflated_sharpe < result_unfloored.deflated_sharpe
+        assert result_floored.z_score < result_unfloored.z_score
+
+
+class TestEffectiveNumberOfTrials:
+    """Tests for correlation-adjusted effective trial counts."""
+
+    def test_effective_rank_identical_strategies_near_one(self):
+        """Perfectly correlated strategies should collapse to one effective trial."""
+        base = np.linspace(-0.02, 0.02, 200)
+        matrix = np.column_stack([base, base, base])
+
+        result = effective_number_of_trials(matrix, method="effective_rank")
+
+        assert result.method == "effective_rank"
+        assert result.k_eff == pytest.approx(1.0, abs=1e-6)
+        assert result.diagnostics["n_strategies"] == 3
+
+    def test_effective_rank_independent_strategies_near_raw_k(self):
+        """Independent strategies should retain most of the raw trial count."""
+        rng = np.random.default_rng(42)
+        matrix = rng.normal(size=(5000, 5))
+
+        result = effective_number_of_trials(matrix, method="effective_rank")
+
+        assert result.k_eff > 4.5
+        assert result.k_eff <= 5.0
+
+    def test_marchenko_pastur_recovers_cluster_count(self):
+        """M-P estimator should recover a small number of latent strategy families."""
+        rng = np.random.default_rng(42)
+        n_periods = 1500
+        n_clusters = 10
+        per_cluster = 5
+        factors = rng.standard_t(df=5, size=(n_periods, n_clusters)) * 0.01
+        strategies = []
+        for cluster_id in range(n_clusters):
+            for _ in range(per_cluster):
+                strategies.append(factors[:, cluster_id] + rng.normal(scale=0.002, size=n_periods))
+        matrix = np.column_stack(strategies)
+
+        result = effective_number_of_trials(matrix, method="marchenko_pastur")
+
+        assert result.mp_upper_bound is not None
+        assert 8 <= result.k_eff <= 12
+
+    def test_clustering_recovers_cluster_count_and_variance(self):
+        """Clustering estimator should recover the number of independent ideas."""
+        rng = np.random.default_rng(42)
+        n_periods = 1200
+        n_clusters = 8
+        per_cluster = 4
+        factors = rng.normal(size=(n_periods, n_clusters)) * 0.01
+        strategies = []
+        for cluster_id in range(n_clusters):
+            for _ in range(per_cluster):
+                strategies.append(factors[:, cluster_id] + rng.normal(scale=0.0015, size=n_periods))
+        matrix = np.column_stack(strategies)
+
+        result = effective_number_of_trials(matrix, method="clustering")
+
+        assert result.n_clusters is not None
+        assert result.variance_trials is not None
+        assert 6 <= result.k_eff <= 10
+        assert result.variance_trials > 0
+        assert len(result.diagnostics["cluster_labels"]) == matrix.shape[1]
 
     def test_dsr_high_variance(self):
         """Test DSR with high variance across trials."""
@@ -1619,6 +1734,139 @@ class TestDeflatedSharpeRatioRawReturns:
         # Expected max Sharpe adjustment should reduce probability
         assert result.expected_max_sharpe >= 0
 
+    def test_multiple_strategy_matrix_input_supported(self):
+        """Test 2D return matrix input is treated as multiple strategies."""
+        from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+
+        rng = np.random.default_rng(42)
+        matrix = rng.normal(loc=[0.0004, 0.001, 0.0002], scale=0.01, size=(252, 3))
+
+        result = deflated_sharpe_ratio(matrix, frequency="daily")
+
+        assert result.n_trials == 3
+        assert result.variance_trials > 0
+
+    def test_correlation_adjusted_dsr_uses_effective_rank(self):
+        """Highly correlated strategies should use K_eff < raw K."""
+        from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+
+        rng = np.random.default_rng(42)
+        base = rng.normal(0.001, 0.01, size=252)
+        strategies = np.column_stack(
+            [
+                base,
+                base + rng.normal(0.0, 0.001, size=252),
+                base + rng.normal(0.0, 0.001, size=252),
+                base + rng.normal(0.0, 0.001, size=252),
+            ]
+        )
+
+        raw_result = deflated_sharpe_ratio(strategies, frequency="daily")
+        adjusted_result = deflated_sharpe_ratio(
+            strategies,
+            frequency="daily",
+            correlation_method="effective_rank",
+        )
+
+        assert adjusted_result.n_trials_raw == 4
+        assert adjusted_result.n_trials_effective is not None
+        assert adjusted_result.n_trials_effective < 4
+        assert adjusted_result.correlation_method == "effective_rank"
+        assert adjusted_result.expected_max_sharpe < raw_result.expected_max_sharpe
+        assert adjusted_result.deflated_sharpe > raw_result.deflated_sharpe
+
+    def test_correlation_adjusted_dsr_supports_marchenko_pastur(self):
+        """DSR should support the M-P effective trial estimator."""
+        from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+
+        rng = np.random.default_rng(7)
+        factors = rng.normal(size=(500, 3)) * 0.01
+        matrix = np.column_stack(
+            [
+                factors[:, 0] + rng.normal(scale=0.001, size=500),
+                factors[:, 0] + rng.normal(scale=0.001, size=500),
+                factors[:, 1] + rng.normal(scale=0.001, size=500),
+                factors[:, 1] + rng.normal(scale=0.001, size=500),
+                factors[:, 2] + rng.normal(scale=0.001, size=500),
+                factors[:, 2] + rng.normal(scale=0.001, size=500),
+            ]
+        )
+
+        result = deflated_sharpe_ratio(
+            matrix,
+            frequency="daily",
+            correlation_method="marchenko_pastur",
+        )
+
+        assert result.n_trials_raw == 6
+        assert result.n_trials_effective is not None
+        assert 2 <= result.n_trials_effective <= 4
+        assert result.correlation_method == "marchenko_pastur"
+
+    def test_correlation_adjusted_dsr_supports_clustering(self):
+        """DSR should support clustering-based effective trial estimation."""
+        from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+
+        rng = np.random.default_rng(11)
+        factors = rng.normal(size=(600, 4)) * 0.01
+        matrix = np.column_stack(
+            [
+                factors[:, 0] + rng.normal(scale=0.001, size=600),
+                factors[:, 0] + rng.normal(scale=0.001, size=600),
+                factors[:, 1] + rng.normal(scale=0.001, size=600),
+                factors[:, 1] + rng.normal(scale=0.001, size=600),
+                factors[:, 2] + rng.normal(scale=0.001, size=600),
+                factors[:, 2] + rng.normal(scale=0.001, size=600),
+                factors[:, 3] + rng.normal(scale=0.001, size=600),
+                factors[:, 3] + rng.normal(scale=0.001, size=600),
+            ]
+        )
+
+        result = deflated_sharpe_ratio(
+            matrix,
+            frequency="daily",
+            correlation_method="clustering",
+        )
+
+        assert result.n_trials_raw == 8
+        assert result.n_trials_effective is not None
+        assert 3 <= result.n_trials_effective <= 5
+        assert result.correlation_method == "clustering"
+
+    def test_correlation_adjusted_dsr_respects_min_k_eff_floor(self):
+        """Estimated K_eff should be floored when min_k_eff is supplied."""
+        from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
+
+        rng = np.random.default_rng(21)
+        base = rng.normal(0.001, 0.01, size=252)
+        strategies = np.column_stack(
+            [
+                base,
+                base + rng.normal(0.0, 0.001, size=252),
+                base + rng.normal(0.0, 0.001, size=252),
+                base + rng.normal(0.0, 0.001, size=252),
+            ]
+        )
+
+        unfloored = deflated_sharpe_ratio(
+            strategies,
+            frequency="daily",
+            correlation_method="effective_rank",
+        )
+        floored = deflated_sharpe_ratio(
+            strategies,
+            frequency="daily",
+            correlation_method="effective_rank",
+            min_k_eff=2.0,
+        )
+
+        assert unfloored.n_trials_effective is not None
+        assert unfloored.n_trials_effective < 2.0
+        assert floored.n_trials_effective == pytest.approx(2.0)
+        assert floored.min_k_eff == pytest.approx(2.0)
+        assert floored.expected_max_sharpe > unfloored.expected_max_sharpe
+        assert floored.deflated_sharpe < unfloored.deflated_sharpe
+
     def test_list_of_single_strategy_treated_as_psr(self):
         """Test that list with single element is treated as PSR."""
         from ml4t.diagnostic.evaluation.stats import deflated_sharpe_ratio
@@ -1800,6 +2048,10 @@ class TestDeflatedSharpeRatioRawReturns:
         assert "sharpe_ratio_annualized" in result_dict
         assert "n_samples" in result_dict
         assert "n_trials" in result_dict
+        assert "n_trials_raw" in result_dict
+        assert "n_trials_effective" in result_dict
+        assert "correlation_method" in result_dict
+        assert "min_k_eff" in result_dict
         assert "skewness" in result_dict
         assert "excess_kurtosis" in result_dict
         assert "min_trl" in result_dict

--- a/tests/test_results_schemas.py
+++ b/tests/test_results_schemas.py
@@ -515,6 +515,10 @@ def test_dsr_result():
         adjusted_pvalue=0.03,
         is_significant=True,
         n_trials=10,
+        n_trials_raw=25,
+        n_trials_effective=8.5,
+        correlation_method="effective_rank",
+        min_k_eff=2.0,
         variance_trials=0.05,
     )
 
@@ -524,11 +528,14 @@ def test_dsr_result():
     df = result.get_dataframe()
     assert isinstance(df, pl.DataFrame)
     assert len(df) == 1
+    assert "n_trials_effective" in df.columns
 
     # Test summary
     summary = result.summary()
     assert "DSR" in summary
     assert "Significant" in summary
+    assert "effective_rank" in summary
+    assert "Minimum K_eff floor" in summary
 
 
 def test_fdr_result():

--- a/uv.lock
+++ b/uv.lock
@@ -1766,8 +1766,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arch", marker = "python_full_version < '3.14'", specifier = ">=7.2.0" },
-    { name = "arch", marker = "python_full_version >= '3.14'", specifier = ">=8.0.0" },
+    { name = "arch", specifier = ">=7.2.0" },
     { name = "cupy-cuda11x", marker = "extra == 'gpu'", specifier = ">=11.0.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.80.0" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.0" },
@@ -1790,20 +1789,17 @@ requires-dist = [
     { name = "ml4t-data", marker = "extra == 'all'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'data'", specifier = ">=0.1.0b7" },
     { name = "ml4t-data", marker = "extra == 'factors'", specifier = ">=0.1.0b7" },
-    { name = "ml4t-engineer", specifier = ">=0.1.0b7" },
+    { name = "ml4t-engineer", specifier = ">=0.1.0b8" },
     { name = "ml4t-specs", specifier = ">=0.1.0b0" },
-    { name = "numba", marker = "python_full_version < '3.14'", specifier = ">=0.57.0" },
-    { name = "numba", marker = "python_full_version >= '3.14'", specifier = ">=0.64.0" },
+    { name = "numba", specifier = ">=0.57.0" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pandas", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
-    { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "pandas-market-calendars", specifier = ">=4.0.0" },
     { name = "plotly", marker = "extra == 'all'", specifier = ">=5.15.0" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.15.0" },
     { name = "polars", specifier = ">=0.20.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.3.0" },
-    { name = "pyarrow", marker = "python_full_version < '3.14'", specifier = ">=14.0.0" },
-    { name = "pyarrow", marker = "python_full_version >= '3.14'", specifier = ">=23.0.0" },
+    { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pypdf", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "pypdf", marker = "extra == 'viz'", specifier = ">=5.0.0" },
@@ -1814,15 +1810,12 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.3.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "scikit-learn", marker = "python_full_version < '3.14'", specifier = ">=1.3.0" },
-    { name = "scikit-learn", marker = "python_full_version >= '3.14'", specifier = ">=1.7.2" },
-    { name = "scipy", marker = "python_full_version < '3.14'", specifier = ">=1.10.0" },
-    { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.17.0" },
+    { name = "scikit-learn", specifier = ">=1.3.0" },
+    { name = "scipy", specifier = ">=1.10.0" },
     { name = "seaborn", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "seaborn", marker = "extra == 'viz'", specifier = ">=0.12.0" },
     { name = "shap", specifier = ">=0.41.0,<0.52.0" },
-    { name = "statsmodels", marker = "python_full_version < '3.14'", specifier = ">=0.14.0" },
-    { name = "statsmodels", marker = "python_full_version >= '3.14'", specifier = ">=0.14.6" },
+    { name = "statsmodels", specifier = ">=0.14.0" },
     { name = "streamlit", marker = "extra == 'all'", specifier = ">=1.28.0" },
     { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.28.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
@@ -1858,7 +1851,7 @@ dev = [
 
 [[package]]
 name = "ml4t-engineer"
-version = "0.1.0b7"
+version = "0.1.0b8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
@@ -1883,9 +1876,9 @@ dependencies = [
     { name = "statsmodels", version = "0.14.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/0c/2027dafe5976a01b02ada57afd45121b84fadd5cf24f186a3d5a2121e709/ml4t_engineer-0.1.0b7.tar.gz", hash = "sha256:ca05202fac42edadf47d873ea78d63fe0c1b32b87c5e56d2287428ed40aab088", size = 539932, upload-time = "2026-05-05T19:03:20.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/84/18dd1f2d1f2921a11dd30acc3891c4dd28e8750cd8c8fd9ee56ab7a1fbf4/ml4t_engineer-0.1.0b8.tar.gz", hash = "sha256:3f9bd6049bf4086e27ba9a60fe5dfb6c720bdd6f6d28c51c58f78c77acd252ce", size = 539956, upload-time = "2026-05-05T21:29:40.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/51/69aa72bb7d82663860b423d3ac54403f5572af29f116d36036e3e09196ae/ml4t_engineer-0.1.0b7-py3-none-any.whl", hash = "sha256:ddbd63684b254d4dbb79e41e838a69a4e02b9d0d28bf3eceb2e78b8901c90d08", size = 363160, upload-time = "2026-05-05T19:03:18.1Z" },
+    { url = "https://files.pythonhosted.org/packages/58/6d/2fd9b0cdcafae12b586232532a30864b72784a77b98c493bd4dcd0d3ae58/ml4t_engineer-0.1.0b8-py3-none-any.whl", hash = "sha256:1f00a140617db8b2977930d760434bdc874bb2f614a65943540a35872fee77e9", size = 363098, upload-time = "2026-05-05T21:29:38.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add correlation-adjusted DSR with effective trial estimators and K_eff metadata
- document the new DSR workflow, cadence guidance, and min_k_eff behavior
- fix pandas 3 timestamp handling in purging/splitters and XGBoost MDI name fallback
- sync uv.lock with the current declared dependency set

## Validation
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run ty check
- uv run --extra docs mkdocs build --strict
- uv build
- uv run pytest tests/ -q

Full suite result: 5222 passed, 21 skipped