### PR TITLE
fix: resolve visualization helper regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0b21] - 2026-05-15
+
+### Fixed
+- **Rolling Sharpe visualization**: `plot_rolling_sharpe()` now derives its
+  window set from externally supplied `RollingMetricsResult` objects when the
+  caller does not pass `windows`, so custom rolling-window analyses no longer
+  render empty figures. The helper also now fails loudly when no requested
+  Sharpe series match and keeps the Sharpe reference annotations inside narrow
+  layouts.
+- **Cost waterfall labels**: `plot_cost_waterfall()` now uses adaptive
+  currency and percentage formatting so small commission and slippage values no
+  longer collapse to misleading labels such as `$-0 (0.0%)`.
+
 ## [0.1.0b20] - 2026-05-11
 
 ### Added

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b20"
+__version__ = "0.1.0b21"
 
 # Sub-modules for advanced usage
 from . import (

--- a/src/ml4t/diagnostic/visualization/backtest/_formatting.py
+++ b/src/ml4t/diagnostic/visualization/backtest/_formatting.py
@@ -1,0 +1,27 @@
+"""Shared display-formatting helpers for backtest visualizations."""
+
+from __future__ import annotations
+
+
+def format_currency_adaptive(value: float) -> str:
+    """Format currency with magnitude-sensitive precision."""
+    abs_value = abs(value)
+    if abs_value >= 100:
+        return f"${value:,.0f}"
+    if abs_value >= 1:
+        return f"${value:,.2f}"
+    if abs_value >= 0.01:
+        return f"${value:,.4f}"
+    return f"${value:.2e}"
+
+
+def format_percent_adaptive(value: float) -> str:
+    """Format percentages with enough precision for small non-zero values."""
+    abs_value = abs(value)
+    if abs_value >= 1:
+        return f"{value:.1f}%"
+    if abs_value >= 0.01:
+        return f"{value:.2f}%"
+    if abs_value > 0:
+        return f"{value:.2g}%"
+    return "0%"

--- a/src/ml4t/diagnostic/visualization/backtest/cost_attribution.py
+++ b/src/ml4t/diagnostic/visualization/backtest/cost_attribution.py
@@ -19,6 +19,10 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from ml4t.diagnostic.visualization._colors import COLORS as _ML4T_COLORS
+from ml4t.diagnostic.visualization.backtest._formatting import (
+    format_currency_adaptive,
+    format_percent_adaptive,
+)
 from ml4t.diagnostic.visualization.core import get_theme_config, validate_theme
 
 if TYPE_CHECKING:
@@ -117,13 +121,13 @@ def plot_cost_waterfall(
 
     # Create hover text with percentages
     if show_percentages and gross_pnl != 0:
-        text = [f"${gross_pnl:,.0f}"]
+        text = [format_currency_adaptive(gross_pnl)]
         for val in values[1:-1]:
             pct = abs(val) / abs(gross_pnl) * 100
-            text.append(f"${val:,.0f} ({pct:.1f}%)")
-        text.append(f"${net_pnl:,.0f}")
+            text.append(f"{format_currency_adaptive(val)} ({format_percent_adaptive(pct)})")
+        text.append(format_currency_adaptive(net_pnl))
     else:
-        text = [f"${v:,.0f}" for v in values]
+        text = [format_currency_adaptive(v) for v in values]
 
     # Colors: green for positive, red for negative
     positive_color = _ML4T_COLORS.get("positive", "#10b981")

--- a/src/ml4t/diagnostic/visualization/portfolio/risk_plots.py
+++ b/src/ml4t/diagnostic/visualization/portfolio/risk_plots.py
@@ -139,7 +139,9 @@ def plot_rolling_sharpe(
     theme = validate_theme(theme)
     theme_config = get_theme_config(theme)
 
-    if windows is None:
+    if rolling_result is not None and windows is None:
+        windows = sorted(rolling_result.sharpe.keys())
+    elif windows is None:
         windows = [63, 126, 252]
 
     # Get rolling metrics
@@ -161,6 +163,7 @@ def plot_rolling_sharpe(
     )
 
     dates = rolling_result.dates.to_list()
+    n_traces = 0
 
     for i, window in enumerate(windows):
         if window in rolling_result.sharpe:
@@ -177,6 +180,12 @@ def plot_rolling_sharpe(
                     hovertemplate=f"{window}d Sharpe: %{{y:.2f}}<extra></extra>",
                 )
             )
+            n_traces += 1
+
+    if n_traces == 0:
+        raise ValueError(
+            "plot_rolling_sharpe: no rolling Sharpe series matched the requested windows"
+        )
 
     # Add reference lines
     fig.add_hline(y=0, line_dash="solid", line_color="gray", line_width=1)
@@ -186,7 +195,7 @@ def plot_rolling_sharpe(
         line_color="green",
         line_width=1,
         annotation_text="Good (1.0)",
-        annotation_position="right",
+        annotation_position="top right",
     )
     fig.add_hline(
         y=2,
@@ -194,12 +203,13 @@ def plot_rolling_sharpe(
         line_color="darkgreen",
         line_width=1,
         annotation_text="Excellent (2.0)",
-        annotation_position="right",
+        annotation_position="top right",
     )
 
     fig.update_layout(
         legend={"yanchor": "top", "y": 0.99, "xanchor": "left", "x": 0.01},
         hovermode="x unified",
+        margin={"r": 80},
     )
 
     return fig

--- a/tests/test_visualization/test_backtest.py
+++ b/tests/test_visualization/test_backtest.py
@@ -456,6 +456,23 @@ class TestCostAttribution:
 
         assert isinstance(fig, go.Figure)
 
+    def test_plot_cost_waterfall_shows_small_costs_precisely(self):
+        """Small but non-zero costs should not round away in bar labels."""
+        from ml4t.diagnostic.visualization.backtest import plot_cost_waterfall
+
+        fig = plot_cost_waterfall(
+            gross_pnl=40000.0,
+            commission=12.34,
+            slippage=8.76,
+        )
+
+        assert isinstance(fig, go.Figure)
+        labels = list(fig.data[0].text)
+        assert any("12.34" in label for label in labels)
+        assert any("8.76" in label for label in labels)
+        assert any("0.03%" in label for label in labels)
+        assert "$-0" not in " ".join(labels)
+
     def test_plot_cost_sensitivity(self, sample_returns):
         """Test cost sensitivity analysis."""
         from ml4t.diagnostic.visualization.backtest import plot_cost_sensitivity

--- a/tests/test_visualization/test_portfolio_plots.py
+++ b/tests/test_visualization/test_portfolio_plots.py
@@ -1,0 +1,57 @@
+"""Tests for portfolio visualization helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import plotly.graph_objects as go
+import polars as pl
+import pytest
+
+from ml4t.diagnostic.evaluation.portfolio_analysis import RollingMetricsResult
+from ml4t.diagnostic.visualization.portfolio import plot_rolling_sharpe
+
+
+def _make_rolling_result(*, windows: list[int]) -> RollingMetricsResult:
+    dates = pl.Series(
+        "date",
+        pl.date_range(pl.date(2024, 1, 1), pl.date(2024, 1, 10), eager=True),
+    )
+    sharpe = {
+        window: pl.Series(f"sharpe_{window}d", np.linspace(0.5, 1.5, len(dates)))
+        for window in windows
+    }
+    return RollingMetricsResult(windows=windows, dates=dates, sharpe=sharpe)
+
+
+class TestRollingSharpePlots:
+    """Regression coverage for rolling Sharpe helpers."""
+
+    def test_plot_rolling_sharpe_honors_custom_windows_from_result(self):
+        """Externally computed windows should drive the rendered traces."""
+        rolling = _make_rolling_result(windows=[365])
+
+        fig = plot_rolling_sharpe(rolling_result=rolling)
+
+        assert isinstance(fig, go.Figure)
+        traces = [trace for trace in fig.data if trace.type == "scatter" and len(trace.x) > 0]
+        assert len(traces) == 1
+        assert traces[0].name == "365d"
+
+    def test_plot_rolling_sharpe_raises_for_non_matching_explicit_windows(self):
+        """Explicit window requests should fail loudly when no series match."""
+        rolling = _make_rolling_result(windows=[365])
+
+        with pytest.raises(ValueError, match="no rolling Sharpe series matched"):
+            plot_rolling_sharpe(rolling_result=rolling, windows=[63, 126, 252])
+
+    def test_plot_rolling_sharpe_reference_annotations_fit_narrow_width(self):
+        """Reference-line labels should stay inside the plot area on narrow figures."""
+        rolling = _make_rolling_result(windows=[63])
+
+        fig = plot_rolling_sharpe(rolling_result=rolling, width=400)
+
+        assert isinstance(fig, go.Figure)
+        assert fig.layout.margin.r == 80
+        annotation_texts = {annotation.text for annotation in fig.layout.annotations}
+        assert "Good (1.0)" in annotation_texts
+        assert "Excellent (2.0)" in annotation_texts


### PR DESCRIPTION
## Summary
- fix plot_rolling_sharpe so externally supplied rolling results drive the rendered window set
- keep rolling Sharpe reference labels readable on narrow layouts and fail loudly on unmatched windows
- use adaptive cost-waterfall label formatting so small costs no longer round to `hBc0 (0.0%)`
- add regression coverage for both visualization helpers
- bump release to 0.1.0b21

## Validation
- uv run pytest tests/test_visualization/test_portfolio_plots.py -q
- uv run pytest tests/test_visualization/test_backtest.py -q -k 'cost_waterfall'
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run ty check
- uv run --extra docs mkdocs build --strict
- uv build
- uv run pytest tests/ -q

Full suite result: 5226 passed, 21 skipped