### PR TITLE
fix: anchor drawdowns at high-water marks

### DIFF
--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0b24"
+__version__ = "0.1.0b25"
 
 # Sub-modules for advanced usage
 from . import (

--- a/src/ml4t/diagnostic/evaluation/portfolio_analysis/analysis.py
+++ b/src/ml4t/diagnostic/evaluation/portfolio_analysis/analysis.py
@@ -570,10 +570,11 @@ class PortfolioAnalysis:
         valley_depth = 0.0
 
         for i, dd in enumerate(underwater):
-            if dd < -threshold and not in_drawdown:
+            if not in_drawdown and dd >= 0:
+                peak_idx = i
+            elif dd < -threshold and not in_drawdown:
                 # Start of drawdown
                 in_drawdown = True
-                peak_idx = i - 1 if i > 0 else 0
                 valley_idx = i
                 valley_depth = dd
             elif in_drawdown:
@@ -593,6 +594,7 @@ class PortfolioAnalysis:
                     )
                     periods.append(period)
                     in_drawdown = False
+                    peak_idx = i
 
         # Handle ongoing drawdown
         if in_drawdown:

--- a/tests/test_evaluation/test_portfolio_analysis.py
+++ b/tests/test_evaluation/test_portfolio_analysis.py
@@ -783,6 +783,21 @@ class TestPortfolioAnalysisDrawdown:
         assert result.max_drawdown <= 0
         assert result.num_drawdowns >= 0
 
+    def test_drawdown_peak_precedes_threshold_crossing(self):
+        """Drawdown periods start at the actual high-water mark."""
+        returns = np.array([0.0, -0.005, -0.010, -0.010, 0.031])
+        dates = pl.date_range(pl.date(2026, 1, 1), pl.date(2026, 1, 5), eager=True)
+
+        result = PortfolioAnalysis(returns=returns, dates=dates).compute_drawdown_analysis(
+            threshold=0.01
+        )
+
+        period = result.top_drawdowns[0]
+        assert period.peak_date == dates[0]
+        assert period.valley_date == dates[3]
+        assert period.recovery_date == dates[4]
+        assert period.duration_days == 3
+
     def test_drawdown_caching(self, portfolio_analysis):
         """Test that drawdown results are cached."""
         result1 = portfolio_analysis.compute_drawdown_analysis()


### PR DESCRIPTION
## What changed

- Anchor each reported drawdown period at its actual high-water mark.
- Preserve that peak while losses remain below the reporting threshold.
- Add a regression test covering delayed threshold crossing.
- Bump the package version to `0.1.0b25`.

## Why

The prior implementation set `peak_date` to the observation immediately before a drawdown crossed the configured threshold. For gradual declines, this shortened the reported drawdown and assigned the wrong peak date. The corrected scan continuously tracks the latest high-water mark outside a drawdown.

## User impact

Drawdown tables and downstream reports now show the true peak date and full peak-to-recovery duration. Maximum drawdown depth is unchanged.

## Validation

- Reproduced b24 behavior: Jan 2 peak, 2-day duration
- Verified b25 behavior: Jan 1 peak, 3-day duration
- `uv run pytest tests/test_evaluation/test_portfolio_analysis.py -q` - 70 passed
- `uv run pytest tests/ -q -n auto --timeout 120` - 5,287 passed, 21 skipped
- `uv run ruff check src/ tests/test_evaluation/test_portfolio_analysis.py`
- `uv run ruff format --check src/ tests/test_evaluation/test_portfolio_analysis.py`
- `uv run ty check`
- `pre-commit run --all-files`
- Built wheel and sdist; installed-wheel smoke test passed for version and corrected drawdown output
