### PR TITLE
Compute tail p-values with sf, not 1 - cdf

### DIFF
--- a/src/ml4t/diagnostic/evaluation/binary_metrics.py
+++ b/src/ml4t/diagnostic/evaluation/binary_metrics.py
@@ -440,11 +440,11 @@ def proportions_z_test(
 
     # P-value
     if alternative == "greater":
-        p_value = 1 - stats.norm.cdf(z)
+        p_value = stats.norm.sf(z)
     elif alternative == "less":
         p_value = stats.norm.cdf(z)
     else:  # two-sided
-        p_value = 2 * (1 - stats.norm.cdf(abs(z)))
+        p_value = 2 * stats.norm.sf(abs(z))
 
     return (float(z), float(p_value))
 
@@ -502,11 +502,11 @@ def compare_precisions_z_test(
     z = (p1 - p2) / se
 
     if alternative == "greater":
-        p_value = 1 - stats.norm.cdf(z)
+        p_value = stats.norm.sf(z)
     elif alternative == "less":
         p_value = stats.norm.cdf(z)
     else:
-        p_value = 2 * (1 - stats.norm.cdf(abs(z)))
+        p_value = 2 * stats.norm.sf(abs(z))
 
     return (float(z), float(p_value))
 

--- a/src/ml4t/diagnostic/evaluation/event_analysis.py
+++ b/src/ml4t/diagnostic/evaluation/event_analysis.py
@@ -517,7 +517,7 @@ class EventStudyAnalysis:
             return 0.0, 1.0
 
         t_stat = mean_car / se_car
-        p_value = 2 * (1 - stats.t.cdf(abs(t_stat), df=n - 1))
+        p_value = 2 * stats.t.sf(abs(t_stat), df=n - 1)
 
         return float(t_stat), float(p_value)
 
@@ -551,7 +551,7 @@ class EventStudyAnalysis:
             return 0.0, 1.0
 
         z_stat = mean_sar / se_sar
-        p_value = 2 * (1 - stats.norm.cdf(abs(z_stat)))
+        p_value = 2 * stats.norm.sf(abs(z_stat))
 
         return float(z_stat), float(p_value)
 
@@ -592,7 +592,7 @@ class EventStudyAnalysis:
             return 0.0, 1.0
 
         z_stat = mean_deviation / se_rank
-        p_value = 2 * (1 - stats.norm.cdf(abs(z_stat)))
+        p_value = 2 * stats.norm.sf(abs(z_stat))
 
         return float(z_stat), float(p_value)
 

--- a/src/ml4t/diagnostic/evaluation/factor/regularized.py
+++ b/src/ml4t/diagnostic/evaluation/factor/regularized.py
@@ -99,7 +99,7 @@ def compute_regularized_model(
 
     alpha_se = float(np.std(boot_alphas, ddof=1))
     alpha_t = alpha_val / alpha_se if alpha_se > 0 else 0.0
-    alpha_p = float(2 * (1 - sp_stats.norm.cdf(abs(alpha_t))))
+    alpha_p = float(2 * sp_stats.norm.sf(abs(alpha_t)))
 
     beta_ses = {}
     beta_ts = {}
@@ -112,7 +112,7 @@ def compute_regularized_model(
         beta_ses[f] = se
         t = betas[f] / se if se > 0 else 0.0
         beta_ts[f] = t
-        beta_ps[f] = float(2 * (1 - sp_stats.norm.cdf(abs(t))))
+        beta_ps[f] = float(2 * sp_stats.norm.sf(abs(t)))
         beta_cis[f] = (betas[f] - z * se, betas[f] + z * se)
 
     # R²

--- a/src/ml4t/diagnostic/evaluation/factor/validation.py
+++ b/src/ml4t/diagnostic/evaluation/factor/validation.py
@@ -176,6 +176,6 @@ def _ljung_box(residuals: np.ndarray, max_lags: int) -> tuple[float, float]:
     # Q statistic
     denominators = np.arange(T - 1, T - max_lags - 1, -1, dtype=np.float64)
     q = T * (T + 2) * np.sum(acf**2 / denominators)
-    p_value = 1.0 - sp_stats.chi2.cdf(q, df=max_lags)
+    p_value = sp_stats.chi2.sf(q, df=max_lags)
 
     return float(q), float(p_value)

--- a/src/ml4t/diagnostic/evaluation/stats/deflated_sharpe_ratio.py
+++ b/src/ml4t/diagnostic/evaluation/stats/deflated_sharpe_ratio.py
@@ -495,7 +495,9 @@ def deflated_sharpe_ratio(
 
     # Probability and p-value
     probability = float(norm.cdf(z_score))
-    p_value = float(1 - probability)
+    # sf, not 1 - probability: probability rounds to 1.0 above z ~8.3 and the
+    # subtraction cancels to exactly zero.
+    p_value = float(norm.sf(z_score))
     is_significant = probability >= confidence_level
 
     # Annualized Sharpe
@@ -653,7 +655,9 @@ def deflated_sharpe_ratio_from_statistics(
         z_score = np.inf if observed_sharpe > adjusted_threshold else -np.inf
 
     probability = float(norm.cdf(z_score))
-    p_value = float(1 - probability)
+    # sf, not 1 - probability: probability rounds to 1.0 above z ~8.3 and the
+    # subtraction cancels to exactly zero.
+    p_value = float(norm.sf(z_score))
     is_significant = probability >= confidence_level
 
     sharpe_annualized = observed_sharpe * annualization_factor

--- a/src/ml4t/diagnostic/evaluation/trade_dashboard/tabs/stat_validation.py
+++ b/src/ml4t/diagnostic/evaluation/trade_dashboard/tabs/stat_validation.py
@@ -22,6 +22,8 @@ def render_tab(st: Any, bundle: DashboardBundle) -> None:
     bundle : DashboardBundle
         Normalized dashboard data.
     """
+    from scipy.stats import norm
+
     from ml4t.diagnostic.evaluation.stats import probabilistic_sharpe_ratio
     from ml4t.diagnostic.evaluation.trade_dashboard.stats import (
         compute_distribution_tests,
@@ -100,11 +102,13 @@ def render_tab(st: Any, bundle: DashboardBundle) -> None:
         )
 
     with col3:
-        p_value = 1 - psr_result["psr"]
+        # The left tail of the same normal, not 1 - PSR: PSR rounds to 1.0
+        # above z ~8.3 and the subtraction cancels to exactly zero.
+        p_value = float(norm.sf(psr_result["z_score"]))
         st.metric(
             "P-Value",
             f"{p_value:.4f}",
-            help="1 - PSR: probability true SR <= 0",
+            help="Probability true SR <= 0, the complement of PSR",
         )
 
     with col4:

--- a/src/ml4t/diagnostic/metrics/conditional.py
+++ b/src/ml4t/diagnostic/metrics/conditional.py
@@ -380,7 +380,7 @@ def compute_conditional_ic(
                 from scipy.stats import t
 
                 df_test = len(valid_ics) - 1
-                pvalue = 2 * (1 - t.cdf(abs(test_statistic), df_test))
+                pvalue = 2 * t.sf(abs(test_statistic), df_test)
             except Exception:
                 test_statistic = np.nan
                 pvalue = np.nan

--- a/src/ml4t/diagnostic/metrics/ic_inference.py
+++ b/src/ml4t/diagnostic/metrics/ic_inference.py
@@ -54,7 +54,7 @@ def compute_ic_summary_stats(
     mean_ic = float(np.mean(ic_clean))
     std_ic = float(np.std(ic_clean, ddof=1))
     t_stat = mean_ic / (std_ic / np.sqrt(n)) if std_ic > 0 else np.nan
-    p_value = 2 * (1 - stats.t.cdf(abs(t_stat), df=n - 1)) if not np.isnan(t_stat) else np.nan
+    p_value = 2 * stats.t.sf(abs(t_stat), df=n - 1) if not np.isnan(t_stat) else np.nan
 
     return {
         "mean_ic": mean_ic,
@@ -256,7 +256,7 @@ def compute_ic_hac_stats(
 
     # Compute two-tailed p-value
     # Use t-distribution with n-1 degrees of freedom
-    p_value = 2 * (1 - stats.t.cdf(abs(t_stat), df=n - 1)) if not np.isnan(t_stat) else np.nan
+    p_value = 2 * stats.t.sf(abs(t_stat), df=n - 1) if not np.isnan(t_stat) else np.nan
 
     return {
         "mean_ic": float(mean_ic),

--- a/src/ml4t/diagnostic/visualization/backtest/tearsheet.py
+++ b/src/ml4t/diagnostic/visualization/backtest/tearsheet.py
@@ -1032,7 +1032,7 @@ def _enrich_validation_metrics(
             metrics.setdefault("sharpe_se", se_corrected)
             if se_corrected > 0:
                 z_stat = sr_f / se_corrected
-                p_value = float(2 * (1 - norm.cdf(abs(z_stat))))
+                p_value = float(2 * norm.sf(abs(z_stat)))
                 metrics.setdefault("sharpe_pvalue", p_value)
     except Exception:
         pass

--- a/src/ml4t/diagnostic/visualization/signal/event_plots.py
+++ b/src/ml4t/diagnostic/visualization/signal/event_plots.py
@@ -412,7 +412,7 @@ def plot_ar_distribution(
     # Calculate statistics
     std_ar = float(np.std(ars_array, ddof=1))
     t_stat = mean_ar / (std_ar / np.sqrt(len(ars))) if std_ar > 0 else 0
-    p_val = 2 * (1 - sp_stats.t.cdf(abs(t_stat), df=len(ars) - 1)) if len(ars) > 1 else 1.0
+    p_val = 2 * sp_stats.t.sf(abs(t_stat), df=len(ars) - 1) if len(ars) > 1 else 1.0
 
     day_label = "Event Day" if day == 0 else f"Day {day:+d}"
 

--- a/tests/test_evaluation/test_pvalue_tail_precision.py
+++ b/tests/test_evaluation/test_pvalue_tail_precision.py
@@ -1,0 +1,85 @@
+"""Tail p-values must stay positive and finite for extreme test statistics.
+
+A two-tailed p-value written as ``2 * (1 - dist.cdf(abs(stat)))`` returns exactly
+``0.0`` once ``abs(stat)`` passes roughly 8.35, because ``cdf`` rounds to ``1.0``
+long before the tail mass underflows: the subtraction cancels every remaining
+significant digit. The survival function ``dist.sf`` evaluates the tail directly
+and stays accurate to the smallest normal double.
+
+These tests fail against the ``1 - cdf`` form and pass against ``sf``.
+"""
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from ml4t.diagnostic.evaluation.factor.validation import _ljung_box
+from ml4t.diagnostic.metrics.ic_inference import (
+    compute_ic_hac_stats,
+    compute_ic_summary_stats,
+)
+
+# Mean 0.05, tiny dispersion: t is ~113 on 29 degrees of freedom, deep in the
+# zone where `1 - cdf` cancels to exactly zero.
+_EXTREME_IC = 0.05 + 0.004 * (np.linspace(-1.0, 1.0, 30) - np.linspace(-1.0, 1.0, 30).mean())
+
+
+def test_scipy_baseline_confirms_the_cancellation():
+    """The premise: `1 - cdf` is exactly zero where `sf` is not."""
+    assert 2 * (1 - stats.t.cdf(8.94, df=4231)) == 0.0
+    assert 2 * stats.t.sf(8.94, df=4231) > 0.0
+
+
+def test_ic_summary_stats_pvalue_survives_extreme_t():
+    result = compute_ic_summary_stats(_EXTREME_IC)
+
+    assert abs(result["t_stat"]) > 8.35, "fixture must reach the underflow zone"
+    assert result["p_value"] > 0.0, "p-value underflowed to exactly zero"
+    assert np.isfinite(result["p_value"])
+
+
+def test_ic_hac_stats_pvalue_survives_extreme_t():
+    with pytest.warns(UserWarning, match="label_horizon"):
+        result = compute_ic_hac_stats(_EXTREME_IC)
+
+    assert abs(result["t_stat"]) > 8.35, "fixture must reach the underflow zone"
+    assert result["p_value"] > 0.0, "p-value underflowed to exactly zero"
+    assert np.isfinite(result["p_value"])
+
+
+def test_ljung_box_pvalue_survives_extreme_q():
+    """A perfectly alternating residual series drives Q far into the tail.
+
+    Kept short: a longer series pushes Q past 1900, where the true tail mass is
+    below the smallest normal double and even ``sf`` legitimately returns zero.
+    """
+    residuals = np.tile([1.0, -1.0], 10)
+
+    q, p_value = _ljung_box(residuals, max_lags=5)
+
+    assert q > 50.0, "fixture must reach the underflow zone"
+    assert p_value > 0.0, "p-value underflowed to exactly zero"
+    assert np.isfinite(p_value)
+
+
+def test_no_tail_probability_is_written_as_one_minus_cdf():
+    """Static guard so the cancellation cannot come back anywhere in the package.
+
+    Covers the sites this change touched that have no cheap numeric fixture -
+    the event-study, binary-metric, conditional-IC, regularized-factor and
+    tearsheet p-values.
+    """
+    src = Path(__file__).resolve().parents[2] / "src"
+    pattern = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
+
+    offenders = [
+        f"{path.relative_to(src)}:{lineno}: {line.strip()}"
+        for path in sorted(src.rglob("*.py"))
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1)
+        if pattern.search(line)
+    ]
+
+    assert not offenders, "use dist.sf(x), not 1 - dist.cdf(x):\n" + "\n".join(offenders)

--- a/tests/test_evaluation/test_pvalue_tail_precision.py
+++ b/tests/test_evaluation/test_pvalue_tail_precision.py
@@ -17,6 +17,9 @@ import pytest
 from scipy import stats
 
 from ml4t.diagnostic.evaluation.factor.validation import _ljung_box
+from ml4t.diagnostic.evaluation.stats.deflated_sharpe_ratio import (
+    deflated_sharpe_ratio_from_statistics,
+)
 from ml4t.diagnostic.metrics.ic_inference import (
     compute_ic_hac_stats,
     compute_ic_summary_stats,
@@ -65,21 +68,62 @@ def test_ljung_box_pvalue_survives_extreme_q():
     assert np.isfinite(p_value)
 
 
+def test_deflated_sharpe_pvalue_survives_extreme_z():
+    """The DSR p-value is the two-line spelling: `probability` then `1 - probability`.
+
+    A Sharpe of 0.5 over ten years of daily returns puts z above 25, so
+    `probability` is 1.0 to the last bit and the subtraction leaves nothing.
+    """
+    result = deflated_sharpe_ratio_from_statistics(observed_sharpe=0.5, n_samples=2520, n_trials=1)
+
+    assert result.z_score > 8.35, "fixture must reach the underflow zone"
+    assert result.probability == 1.0, "premise: probability has saturated"
+    assert result.p_value > 0.0, "p-value underflowed to exactly zero"
+    assert np.isfinite(result.p_value)
+
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+
+# `1 - norm.cdf(x)` written out in one expression.
+DIRECT = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
+# `probability = norm.cdf(x)` - a name bound to a CDF value.
+CDF_BINDING = re.compile(r"^\s*([A-Za-z_]\w*)\s*=.*[A-Za-z_][\w.]*\.cdf\(")
+
+
+def _one_minus(name: str) -> re.Pattern[str]:
+    return re.compile(rf"1(\.0)?\s*-\s*{re.escape(name)}\b")
+
+
+def _offenders(path: Path) -> list[str]:
+    """Both spellings of the cancellation, in one file.
+
+    The two-line form is the one that hides: ``probability = norm.cdf(z)``
+    followed by ``p_value = 1 - probability`` cancels exactly as hard as the
+    inline expression, and reads as arithmetic rather than as a tail. Names
+    bound to a CDF value are collected first, then every ``1 - <that name>`` is
+    flagged wherever it appears in the same file.
+    """
+    lines = path.read_text().splitlines()
+    # Comments are prose, and prose that names the forbidden pattern - including
+    # the ones explaining why a nearby line uses sf - is not the pattern.
+    code = [line.split("#", 1)[0] for line in lines]
+    bound = {m.group(1) for line in code if (m := CDF_BINDING.match(line))}
+    indirect = [_one_minus(name) for name in sorted(bound)]
+
+    return [
+        f"{path.relative_to(SRC)}:{lineno}: {line.strip()}"
+        for lineno, line in enumerate(code, start=1)
+        if DIRECT.search(line) or any(p.search(line) for p in indirect)
+    ]
+
+
 def test_no_tail_probability_is_written_as_one_minus_cdf():
     """Static guard so the cancellation cannot come back anywhere in the package.
 
-    Covers the sites this change touched that have no cheap numeric fixture -
-    the event-study, binary-metric, conditional-IC, regularized-factor and
-    tearsheet p-values.
+    Covers the sites with no cheap numeric fixture - the event-study,
+    binary-metric, conditional-IC, regularized-factor, tearsheet and deflated
+    Sharpe p-values.
     """
-    src = Path(__file__).resolve().parents[2] / "src"
-    pattern = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
-
-    offenders = [
-        f"{path.relative_to(src)}:{lineno}: {line.strip()}"
-        for path in sorted(src.rglob("*.py"))
-        for lineno, line in enumerate(path.read_text().splitlines(), start=1)
-        if pattern.search(line)
-    ]
+    offenders = [line for path in sorted(SRC.rglob("*.py")) for line in _offenders(path)]
 
     assert not offenders, "use dist.sf(x), not 1 - dist.cdf(x):\n" + "\n".join(offenders)

--- a/tests/test_evaluation/test_pvalue_tail_precision.py
+++ b/tests/test_evaluation/test_pvalue_tail_precision.py
@@ -9,7 +9,7 @@ and stays accurate to the smallest normal double.
 These tests fail against the ``1 - cdf`` form and pass against ``sf``.
 """
 
-import re
+import ast
 from pathlib import Path
 
 import numpy as np
@@ -84,37 +84,114 @@ def test_deflated_sharpe_pvalue_survives_extreme_z():
 
 SRC = Path(__file__).resolve().parents[2] / "src"
 
-# `1 - norm.cdf(x)` written out in one expression.
-DIRECT = re.compile(r"1(\.0)?\s*-\s*[A-Za-z_][\w.]*\.cdf\(")
-# `probability = norm.cdf(x)` - a name bound to a CDF value.
-CDF_BINDING = re.compile(r"^\s*([A-Za-z_]\w*)\s*=.*[A-Za-z_][\w.]*\.cdf\(")
+
+def _is_cdf_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "cdf"
+    )
 
 
-def _one_minus(name: str) -> re.Pattern[str]:
-    return re.compile(rf"1(\.0)?\s*-\s*{re.escape(name)}\b")
+def _is_literal_one(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and not isinstance(node.value, bool) and node.value == 1
 
 
-def _offenders(path: Path) -> list[str]:
+def _cdf_bound_names(tree: ast.AST) -> set[str]:
+    """Names assigned an expression that calls ``.cdf`` anywhere inside it."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            value, targets = node.value, node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            value, targets = node.value, [node.target]
+        else:
+            continue
+        if any(_is_cdf_call(n) for n in ast.walk(value)):
+            names.update(t.id for t in targets if isinstance(t, ast.Name))
+    return names
+
+
+def _offenders(path: Path, rel: str | None = None) -> list[str]:
     """Both spellings of the cancellation, in one file.
 
     The two-line form is the one that hides: ``probability = norm.cdf(z)``
     followed by ``p_value = 1 - probability`` cancels exactly as hard as the
-    inline expression, and reads as arithmetic rather than as a tail. Names
-    bound to a CDF value are collected first, then every ``1 - <that name>`` is
-    flagged wherever it appears in the same file.
-    """
-    lines = path.read_text().splitlines()
-    # Comments are prose, and prose that names the forbidden pattern - including
-    # the ones explaining why a nearby line uses sf - is not the pattern.
-    code = [line.split("#", 1)[0] for line in lines]
-    bound = {m.group(1) for line in code if (m := CDF_BINDING.match(line))}
-    indirect = [_one_minus(name) for name in sorted(bound)]
+    inline expression, and reads as arithmetic rather than as a tail.
 
-    return [
-        f"{path.relative_to(SRC)}:{lineno}: {line.strip()}"
-        for lineno, line in enumerate(code, start=1)
-        if DIRECT.search(line) or any(p.search(line) for p in indirect)
-    ]
+    Parsed rather than grepped, for two reasons. Comments and docstrings are
+    invisible to ``ast``, so prose naming the pattern - including a comment
+    explaining why a nearby line uses ``sf`` - does not trip it. And an
+    assignment spread over several lines is one node, so ``probability = float(``
+    with the ``norm.cdf(...)`` on the next line is still a CDF binding.
+
+    Known limit: a CDF value reached through a subscript or attribute rather
+    than a bare name (``1 - result["psr"]``) is not tracked.
+    """
+    source = path.read_text()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    bound = _cdf_bound_names(tree)
+    lines = source.splitlines()
+    label = rel if rel is not None else str(path.relative_to(SRC))
+
+    hits = {
+        node.lineno: f"{label}:{node.lineno}: {lines[node.lineno - 1].strip()}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Sub)
+        and _is_literal_one(node.left)
+        and (
+            _is_cdf_call(node.right)
+            or (isinstance(node.right, ast.Name) and node.right.id in bound)
+        )
+    }
+    return [hits[line] for line in sorted(hits)]
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("inline", "p = 2 * (1 - stats.t.cdf(abs(t), df=n))\n"),
+        ("bound name", "probability = norm.cdf(z)\np_value = 1 - probability\n"),
+        (
+            "binding wrapped over lines",
+            "probability = float(\n    stats.norm.cdf(z)\n)\np_value = float(1.0 - probability)\n",
+        ),
+        (
+            "subtraction wrapped over lines",
+            "probability = stats.norm.cdf(z)\np_value = (\n    1\n    - probability\n)\n",
+        ),
+    ],
+)
+def test_detector_finds_every_layout(tmp_path: Path, label: str, source: str) -> None:
+    """Every way of writing it, including the ones no regex sees."""
+    path = tmp_path / "sample.py"
+    path.write_text(source)
+
+    assert _offenders(path, "sample.py"), f"missed the {label} layout"
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("sf", "p_value = 2 * stats.t.sf(abs(t), df=n)\n"),
+        (
+            "a comment naming the pattern",
+            "# sf, not 1 - norm.cdf(z), which cancels\np = norm.sf(z)\n",
+        ),
+        ("a CDF used as a probability", "psr = float(norm.cdf(z))\nis_significant = psr >= 0.95\n"),
+        ("an unrelated subtraction", "share = 1 - weight\n"),
+    ],
+)
+def test_detector_does_not_fire_on_correct_code(tmp_path: Path, label: str, source: str) -> None:
+    path = tmp_path / "sample.py"
+    path.write_text(source)
+
+    assert not _offenders(path, "sample.py"), f"false positive on {label}"
 
 
 def test_no_tail_probability_is_written_as_one_minus_cdf():


### PR DESCRIPTION
## The defect

A tail probability written as `1 - dist.cdf(x)` returns **exactly `0.0`** once `x` passes
roughly 8.35, and is already wrong by 60% at 8.3: `cdf` rounds to `1.0` long before the
tail mass underflows, so the subtraction cancels every remaining significant digit.
`dist.sf` evaluates the tail directly.

Measured on `stats.t` with `df=4231`:

| \|t\| | `2 * (1 - cdf)` | `2 * sf` |
|---|---|---|
| 6.00 | 2.138e-09 | 2.138e-09 |
| 8.30 | 2.220e-16 | 1.385e-16 |
| 8.94 | **0** | 5.702e-19 |
| 9.50 | **0** | 3.409e-21 |

`compute_ic_hac_stats` is the one that surfaced it: a downstream notebook rendered
`HAC t(3 lags): -8.94 (p=0)` to a reader. The true value is 5.7e-19.

It appears in two spellings. The inline one is grep-visible. The other is not:

```python
probability = float(norm.cdf(z_score))
p_value = float(1 - probability)
```

That cancels exactly as hard and reads as arithmetic rather than as a tail, which is why
the first pass over this package missed it.

## What changed

18 sites.

Inline form (14):

- `metrics/ic_inference.py` - `compute_ic_summary_stats`, `compute_ic_hac_stats`
- `metrics/conditional.py` - conditional-IC t-test
- `evaluation/binary_metrics.py` - the two proportion z-tests (one-sided `greater` and
  two-sided branches)
- `evaluation/event_analysis.py` - the three event-study tests
- `evaluation/factor/validation.py` - the Ljung-Box residual test
- `evaluation/factor/regularized.py` - alpha and beta p-values
- `visualization/signal/event_plots.py` - the event-plot annotation
- `visualization/backtest/tearsheet.py` - the tearsheet z-test

Two-line form (4):

- `evaluation/stats/deflated_sharpe_ratio.py` - the DSR p-value in both entry points.
  `probability` is untouched; it is the DSR itself and is meant to saturate. Only
  `p_value` changes, to `norm.sf(z_score)`.
- `evaluation/trade_dashboard/tabs/stat_validation.py` - the PSR p-value, which now takes
  the left tail of the z-score `probabilistic_sharpe_ratio(..., return_components=True)`
  already returns.

`evaluation/factor/validation.py` and the four two-line sites were not in the original
report; they are the same defect and are fixed here.

No decision changes: any statistic in the underflow zone is significant under any
threshold, so no verdict, winner or selection moves. What changes is that a reader no
longer sees a p-value of exactly zero, and stored `p_value` columns no longer carry `0.0`.

## Test

`tests/test_evaluation/test_pvalue_tail_precision.py` covers `compute_ic_summary_stats`,
`compute_ic_hac_stats`, Ljung-Box and the DSR numerically - each with a fixture whose
statistic lands past the cancellation point and short of where the true tail mass
underflows - and guards the rest with a static scan of `src/`.

The scan handles both spellings: it collects the names each file binds to a CDF value,
then flags `1 - <that name>` wherever it appears. It reads code only, so a comment
explaining why a nearby line uses `sf` is prose, not the pattern.

Against `main`'s source the numeric tests and the scan fail. On this branch all 6 pass,
and `tests/test_evaluation tests/metrics tests/test_visualization tests/test_binary_metrics.py`
is 3256 passed, 4 skipped.