### PR TITLE
test: make performance timing deterministic

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -179,13 +179,15 @@ class TestLoggerFunctions:
 class TestPerformanceTracker:
     """Tests for PerformanceTracker class."""
 
-    def test_basic_timing(self):
+    def test_basic_timing(self, monkeypatch: pytest.MonkeyPatch):
         """Test basic timing functionality."""
-        with PerformanceTracker("test_op") as tracker:
-            time.sleep(0.05)
+        clock = iter((100.0, 100.05))
+        monkeypatch.setattr("ml4t.diagnostic.logging.performance.time.time", lambda: next(clock))
 
-        assert tracker.elapsed >= 0.05
-        assert tracker.elapsed < 0.2
+        with PerformanceTracker("test_op") as tracker:
+            pass
+
+        assert tracker.elapsed == pytest.approx(0.05)
 
     def test_elapsed_before_complete(self):
         """Test elapsed returns current time while running."""


### PR DESCRIPTION
## Summary
- replace the scheduler-sensitive wall-clock bound in `PerformanceTracker` timing coverage with a controlled clock
- assert the exact elapsed interval without sleeping

## Release failure reproduced
The macOS/Python 3.14 release job measured 0.2000458 seconds and failed the previous `< 0.2` assertion after a 0.05-second sleep.

## Verification
- `uv run pytest tests/ -q -n auto --timeout 120` (5,353 passed, 21 skipped)
- `uv run ruff check src/ tests/test_logging.py`
- `uv run ruff format --check src/ tests/test_logging.py`
- `uv run ty check`
- `pre-commit run --all-files`