### PR TITLE
fix: make plot_cv_folds exportable and declare its date axis

### DIFF
--- a/src/ml4t/diagnostic/visualization/cv_plots.py
+++ b/src/ml4t/diagnostic/visualization/cv_plots.py
@@ -310,8 +310,20 @@ def _format_range_label(
 def _get_x_value(
     value: int | pd.Timestamp,
     has_timestamps: bool,
-) -> int | pd.Timestamp:
+) -> int | str:
     """Get x-axis value for plotting.
+
+    A ``pd.Timestamp`` is returned as an ISO 8601 string rather than as itself.
+    Plotly's own encoder accepts a ``Timestamp``, so the figure could always be
+    converted with ``plotly.io.to_json``, but static export goes through Kaleido,
+    which serializes with ``orjson`` and rejects it outright::
+
+        TypeError: Type is not JSON serializable: Timestamp
+
+    So ``fig.to_image()`` raised, and a notebook executed with ``nbconvert``
+    errored on the cell instead of emitting the PNG that GitHub renders. The
+    matching bar widths already come back from :func:`_compute_bar_width` as
+    milliseconds for the same reason.
 
     Parameters
     ----------
@@ -322,9 +334,11 @@ def _get_x_value(
 
     Returns
     -------
-    x_value : int or pd.Timestamp
-        Value suitable for x-axis.
+    x_value : int or str
+        Value suitable for x-axis, and serializable by any JSON encoder.
     """
+    if has_timestamps and isinstance(value, pd.Timestamp):
+        return value.isoformat()
     return value
 
 
@@ -658,6 +672,15 @@ def plot_cv_folds(
             "x": 1,
         },
     )
+
+    if has_timestamps:
+        # Declared, not inferred. Every bar is now an ISO 8601 string base and a width
+        # in milliseconds, and with no explicit type Plotly reads that pair as a linear
+        # axis: it came out labelled 0, 50B, 100B ... with every fold starting at the
+        # origin, which a reader sees as all folds sharing a start date. Inference gave
+        # a date axis only while the base was a Timestamp object, so the change that
+        # makes the figure exportable is exactly the one that would break its axis.
+        fig.update_xaxes(type="date")
 
     # Apply responsive layout
     apply_responsive_layout(fig)

--- a/tests/test_visualization/test_cv_plots.py
+++ b/tests/test_visualization/test_cv_plots.py
@@ -627,6 +627,67 @@ class TestPlotCvFoldsXAxis:
         fig = plot_cv_folds(walk_forward_cv, sample_data_numpy)
         assert fig.layout.title.text == "Cross-Validation Fold Structure"
 
+    def test_xaxis_type_is_declared_as_date(
+        self,
+        walk_forward_cv: WalkForwardCV,
+        sample_data_pandas: pd.DataFrame,
+    ) -> None:
+        """The axis type is set, not left to inference.
+
+        Every bar is a base plus a width in milliseconds. With no declared type
+        Plotly reads that as linear and draws the axis as 0, 50B, 100B ... with
+        every fold starting at the origin, which reads as all folds sharing a
+        start date.
+        """
+        fig = plot_cv_folds(walk_forward_cv, sample_data_pandas)
+        assert fig.layout.xaxis.type == "date"
+
+    def test_xaxis_type_is_left_alone_without_timestamps(
+        self,
+        walk_forward_cv: WalkForwardCV,
+        sample_data_numpy: np.ndarray,
+    ) -> None:
+        """Sample indices are not dates, so nothing is declared for them."""
+        fig = plot_cv_folds(walk_forward_cv, sample_data_numpy)
+        assert fig.layout.xaxis.type != "date"
+
+
+class TestPlotCvFoldsSerialization:
+    """The figure has to survive a static export, not only a Plotly round-trip."""
+
+    def test_bar_bases_carry_no_pandas_objects(
+        self,
+        walk_forward_cv: WalkForwardCV,
+        sample_data_pandas: pd.DataFrame,
+    ) -> None:
+        """A `pd.Timestamp` base is what made static export impossible.
+
+        Plotly's own encoder accepts one, so `plotly.io.to_json` always worked and
+        hid this. Kaleido serializes with `orjson`, which does not.
+        """
+        fig = plot_cv_folds(walk_forward_cv, sample_data_pandas)
+        bases = [value for trace in fig.data for value in (trace.base or ())]
+        assert bases, "the fixture drew no bars, so this asserts nothing"
+        for base in bases:
+            assert not isinstance(base, pd.Timestamp | pd.Timedelta)
+            assert isinstance(base, str)
+
+    def test_figure_serializes_with_a_strict_json_encoder(
+        self,
+        walk_forward_cv: WalkForwardCV,
+        sample_data_pandas: pd.DataFrame,
+    ) -> None:
+        """The check that matches what Kaleido does on `fig.to_image()`.
+
+        Asserted through `json.dumps` rather than by exporting an image, so it
+        holds on a machine with no Chrome for Kaleido to drive.
+        """
+        import json
+
+        fig = plot_cv_folds(walk_forward_cv, sample_data_pandas)
+        for trace in fig.data:
+            json.dumps({"base": list(trace.base or ()), "x": list(trace.x or ())})
+
 
 class TestPlotCvFoldsWithYAndGroups:
     """Tests with y and groups parameters."""


### PR DESCRIPTION
`plot_cv_folds` returned a figure that could not be exported to a static image, and whose
x axis drew as epoch milliseconds if it was forced through.

## What was wrong

Each bar carried a `pd.Timestamp` as its `base` and a duration in milliseconds as its width.
Plotly's own encoder accepts a `Timestamp`, so `plotly.io.to_json` always worked and hid this.
Kaleido serializes with `orjson`, which does not:

```
TypeError: Type is not JSON serializable: Timestamp
```

So `fig.to_image()` raised, and a notebook containing the figure and executed with
`jupyter nbconvert --execute` errored on the cell rather than emitting the PNG that GitHub
renders alongside the interactive figure.

## The fix, and the trap in it

`_get_x_value` now returns an ISO 8601 string for a timestamp, matching `_compute_bar_width`,
which already returned milliseconds for exactly this reason.

**That alone would have traded one defect for a worse one.** The axis type was never declared;
Plotly inferred a date axis only because the base was a `Timestamp` object. With an ISO string
base and a bare-number width it infers *linear* instead, and the chart draws with an axis
labelled `0, 50B, 100B, 150B` and every fold starting at the origin - which reads as all folds
sharing a start date. So the type is now declared rather than inferred, and only when the data
actually carries timestamps.

## Verification

`fig.to_image(format="png")` succeeds on a business-day timeline over 2015-2023, and the
exported image shows an expanding-window walk-forward on a 2015-2023 date axis, with the purge
gap visible between each training block and its validation block.

Five new tests. **Three of them fail on the previous source and pass on this one** - confirmed
by stashing the source change and re-running. The serialization test asserts through
`json.dumps` rather than by exporting an image, so it holds on a machine with no Chrome for
Kaleido to drive.

403 tests in `tests/test_visualization/` pass.
