### PR TITLE
fix: session grid from the timestamp span, and missing="conservative" keeps its gaps

### DIFF
--- a/src/ml4t/diagnostic/evaluation/autocorrelation.py
+++ b/src/ml4t/diagnostic/evaluation/autocorrelation.py
@@ -175,7 +175,7 @@ def _validate_and_prepare(
             "Data contains NaN values",
             context={"nan_count": nan_count, "total_count": len(values)},
         )
-    elif missing in ["conservative", "drop"] and np.any(np.isnan(values)):
+    elif missing == "drop" and np.any(np.isnan(values)):
         original_length = len(values)
         values = values[~np.isnan(values)]
         logger.info(
@@ -184,19 +184,25 @@ def _validate_and_prepare(
             clean_length=len(values),
         )
 
+    # 'conservative' means statsmodels removes each NaN pairwise, at the lag it
+    # affects, and keeps the gap in place. Dropping the NaN here instead would
+    # close the gap and make it a synonym for 'drop': the pair that straddles a
+    # missing period would be counted one lag too early.
+    n_valid = int(np.count_nonzero(~np.isnan(values)))
+
     # Check all NaN
-    if len(values) == 0:
+    if n_valid == 0:
         raise ValidationError("All data is NaN after missing value handling")
 
     # Minimum observations
     min_obs = 5 if kind == "pacf" else 3
-    if len(values) < min_obs:
+    if n_valid < min_obs:
         raise ValidationError(
             f"Insufficient data for {kind.upper()} computation (need at least {min_obs} observations)",
-            context={"n_obs": len(values)},
+            context={"n_obs": n_valid},
         )
 
-    n_obs = len(values)
+    n_obs = n_valid
 
     # Determine nlags
     if nlags is None:
@@ -260,7 +266,8 @@ def compute_acf(
     logger.debug("Computing ACF", fft=fft, missing_handling=missing)
 
     values, nlags = _validate_and_prepare(data, nlags, "acf", missing)
-    n_obs = len(values)
+    # Under 'conservative' the gaps are still in `values`; they are not observations.
+    n_obs = int(np.count_nonzero(~np.isnan(values)))
 
     try:
         acf_values, conf_int = acf(values, nlags=nlags, alpha=alpha, fft=fft, missing=missing)

--- a/src/ml4t/diagnostic/splitters/calendar.py
+++ b/src/ml4t/diagnostic/splitters/calendar.py
@@ -125,6 +125,26 @@ class TradingCalendar:
             # Tz-aware data - convert to calendar timezone
             return timestamps.tz_convert(self.tz)
 
+    @staticmethod
+    def _schedule_span(timestamps: pd.DatetimeIndex) -> tuple[pd.Timestamp, pd.Timestamp]:
+        """Return the dates the exchange schedule has to cover, with a week of buffer.
+
+        Taken from the minimum and maximum, not from the first and last element: a
+        caller that hands over an unordered index would otherwise get a schedule
+        spanning only ``[timestamps[0], timestamps[-1]]``, and every timestamp outside
+        that span would be mapped into the wrong part of the calendar with nothing
+        raised.
+
+        Raises
+        ------
+        ValueError
+            If the index is empty or holds no valid timestamp, so there is no span.
+        """
+        first, last = timestamps.min(), timestamps.max()
+        if pd.isna(first) or pd.isna(last):
+            raise ValueError("timestamps must contain at least one valid timestamp")
+        return first.normalize() - pd.Timedelta(days=7), last.normalize() + pd.Timedelta(days=7)
+
     def get_sessions(
         self,
         timestamps: pd.DatetimeIndex,
@@ -135,6 +155,9 @@ class TradingCalendar:
         For stocks, it's the standard trading day.
 
         Uses vectorized pandas operations for efficiency - handles 1M+ timestamps quickly.
+
+        The result does not depend on the order of the input: the same timestamps
+        shuffled return the same sessions, in the caller's order.
 
         Parameters
         ----------
@@ -150,8 +173,7 @@ class TradingCalendar:
         timestamps_tz = self._ensure_timezone_aware(timestamps)
 
         # Get schedule for the data period (with buffer for edge cases)
-        start_date = timestamps_tz[0].normalize() - pd.Timedelta(days=7)
-        end_date = timestamps_tz[-1].normalize() + pd.Timedelta(days=7)
+        start_date, end_date = self._schedule_span(timestamps_tz)
 
         # Get schedule (~250 sessions/year, very small)
         schedule = self._schedule(start_date=start_date, end_date=end_date)
@@ -210,6 +232,8 @@ class TradingCalendar:
         Unlike get_sessions(), this method does NOT forward-fill non-trading timestamps.
         Non-trading rows (weekends, holidays) get NaT session and False mask.
 
+        The result does not depend on the order of the input.
+
         Parameters
         ----------
         timestamps : pd.DatetimeIndex
@@ -226,8 +250,7 @@ class TradingCalendar:
         timestamps_tz = self._ensure_timezone_aware(timestamps)
 
         # Get schedule for the data period (with buffer for edge cases)
-        start_date = timestamps_tz[0].normalize() - pd.Timedelta(days=7)
-        end_date = timestamps_tz[-1].normalize() + pd.Timedelta(days=7)
+        start_date, end_date = self._schedule_span(timestamps_tz)
 
         valid_days = self.calendar.valid_days(start_date=start_date, end_date=end_date, tz="UTC")
         trading_dates = set(valid_days.tz_localize(None).normalize())

--- a/tests/test_evaluation/test_autocorrelation.py
+++ b/tests/test_evaluation/test_autocorrelation.py
@@ -324,6 +324,37 @@ class TestComputeACF:
         result = compute_acf(data, nlags=10, missing="conservative")
         assert result.n_obs == 95
 
+    def test_conservative_keeps_the_gap_where_drop_closes_it(self):
+        """'conservative' has to reach statsmodels with the gaps still in place.
+
+        The NaN used to be stripped before the call, which made 'conservative' a
+        synonym for 'drop': the pair that straddles a missing observation was
+        counted one lag too early instead of being removed at the lag it affects.
+        """
+        from statsmodels.tsa.stattools import acf as sm_acf
+
+        values = np.sin(np.arange(200, dtype=float) / 2)
+        holed = values.copy()
+        holed[70] = np.nan
+
+        conservative = compute_acf(holed, nlags=5, fft=False, missing="conservative")
+        dropped = compute_acf(holed, nlags=5, fft=False, missing="drop")
+
+        np.testing.assert_allclose(
+            conservative.values,
+            sm_acf(holed, nlags=5, fft=False, missing="conservative"),
+            rtol=1e-12,
+        )
+        np.testing.assert_allclose(
+            dropped.values,
+            sm_acf(values[~np.isnan(holed)], nlags=5, fft=False),
+            rtol=1e-12,
+        )
+        assert not np.allclose(conservative.values, dropped.values), (
+            "'conservative' and 'drop' returned the same curve, so the gap was closed "
+            "before statsmodels saw it"
+        )
+
 
 class TestACFValidation:
     """Tests for ACF input validation."""

--- a/tests/test_splitters/test_calendar.py
+++ b/tests/test_splitters/test_calendar.py
@@ -417,6 +417,72 @@ class TestCalendarSessionsEdgeCases:
         assert list(sessions.index) == list(timestamps)
 
 
+class TestUnorderedTimestamps:
+    """A shuffled index must return the same sessions as a sorted one.
+
+    The exchange schedule used to be built from `timestamps[0]` and
+    `timestamps[-1]`, so anything outside that span was mapped into the wrong
+    part of the calendar: unsorted, 2000-07-04 came back as session 2001-09-04.
+    Nothing raised, and the mapping of a timestamp inside the span was correct,
+    which is why a spot check did not find it.
+    """
+
+    # Spans two calendar years and includes a holiday, a session, and 9/11.
+    DATES = [
+        "2001-09-11",
+        "2001-09-12",
+        "2001-09-17",
+        "2000-07-04",  # Independence Day, not a session
+        "2000-07-05",  # is itself a session
+        "2015-12-31",
+    ]
+
+    def _index(self, dates: list[str]) -> pd.DatetimeIndex:
+        return pd.DatetimeIndex(dates, tz="UTC")
+
+    def test_get_sessions_is_order_independent(self):
+        cal = TradingCalendar("NYSE")
+
+        shuffled = cal.get_sessions(self._index(self.DATES))
+        ordered = cal.get_sessions(self._index(sorted(self.DATES)))
+
+        assert shuffled.sort_index().to_list() == ordered.to_list()
+
+    def test_get_sessions_maps_a_holiday_to_the_next_session(self):
+        """The value the endpoint-derived schedule got wrong, stated directly."""
+        cal = TradingCalendar("NYSE")
+
+        sessions = cal.get_sessions(self._index(self.DATES))
+
+        assert sessions[pd.Timestamp("2000-07-04", tz="UTC")] == pd.Timestamp("2000-07-05")
+        assert sessions[pd.Timestamp("2000-07-05", tz="UTC")] == pd.Timestamp("2000-07-05")
+        assert sessions[pd.Timestamp("2001-09-11", tz="UTC")] == pd.Timestamp("2001-09-17")
+
+    def test_get_sessions_and_mask_is_order_independent(self):
+        cal = TradingCalendar("NYSE")
+
+        shuffled_sessions, shuffled_mask = cal.get_sessions_and_mask(self._index(self.DATES))
+        ordered_sessions, ordered_mask = cal.get_sessions_and_mask(self._index(sorted(self.DATES)))
+
+        order = shuffled_sessions.index.argsort()
+        assert shuffled_sessions.sort_index().to_list() == ordered_sessions.to_list()
+        assert list(shuffled_mask[order]) == list(ordered_mask)
+
+    def test_get_sessions_and_mask_finds_the_trading_day(self):
+        cal = TradingCalendar("NYSE")
+
+        sessions, mask = cal.get_sessions_and_mask(self._index(self.DATES))
+
+        assert mask[self.DATES.index("2000-07-05")]  # a session, unsorted said it was not
+        assert not mask[self.DATES.index("2000-07-04")]  # a holiday
+
+    def test_empty_index_is_rejected(self):
+        cal = TradingCalendar("NYSE")
+
+        with pytest.raises(ValueError, match="at least one valid timestamp"):
+            cal.get_sessions(pd.DatetimeIndex([], tz="UTC"))
+
+
 class TestGetSessionsAndMask:
     """Tests for TradingCalendar.get_sessions_and_mask()."""
 


### PR DESCRIPTION
Two silent-wrong-answer defects, both where an input the function did not expect is
handled as if it were the expected one.

Closes #31.

## `TradingCalendar` built its schedule from the endpoints (#31)

`get_sessions` and `get_sessions_and_mask` derived the exchange schedule from
`timestamps[0]` and `timestamps[-1]`, then searchsorted against it. Handed an index
that was not in ascending order, every timestamp outside `[first, last]` was mapped
into the wrong part of the calendar with nothing raised.

Six NYSE dates, unsorted:

```
2000-07-04 -> 2001-09-04   wrong, the next session is 2000-07-05
2000-07-05 -> 2001-09-04   wrong, it is itself a session
2001-09-11 -> 2001-09-17   right
```

A timestamp inside the span was always correct, which is why a spot check did not
find it. `get_sessions_and_mask` carried the same construction and went further:
unsorted, it reported 2000-07-05 as not a trading day.

The span now comes from `min()` and `max()`. An index with no valid timestamp raises
`ValueError` rather than `IndexError` from the endpoint lookup.

Measured against the only unsorted caller in the book's case studies, an FX panel of
478,640 four-hour bars whose `timestamps[0]` is four hours later than its minimum:
the seven-day buffer already covered it and **0 session assignments change**. The
exposure is a future caller, not a current result.

## `missing="conservative"` was a synonym for `missing="drop"`

`_validate_and_prepare` stripped the NaN values for both options before calling
statsmodels, so the gap was closed rather than preserved and the pair straddling a
missing observation was counted one lag too early instead of being removed at the
lag it affects.

On a 20-point sine with one hole, against the ungapped truth
`[1, 0.8587, 0.5325, 0.1203, -0.2694]`:

```
drop          1, 0.8279, 0.4560, 0.0066, -0.3889
conservative  1, 0.8184, 0.4979, 0.0971, -0.2785    (now; was identical to drop)
```

Only `"drop"` strips now. The observation count used for the minimum-length check,
the automatic `nlags` and the reported `n_obs` counts non-NaN values, so it is
unchanged for `"drop"` and correct rather than inflated for `"conservative"`.

## Tests

- `TestUnorderedTimestamps` in `tests/test_splitters/test_calendar.py` - order
  independence for both methods, the holiday mapping stated directly, and the empty
  index. All five fail without the fix.
- `test_conservative_keeps_the_gap_where_drop_closes_it` - both options against
  statsmodels, and that they no longer agree with each other.

Full suite: 5359 passed, 21 skipped. `ruff check`, `ruff format`, `ty check` clean.