### PR TITLE
fix: seed the stationary bootstrap so its p-value reproduces

### DIFF
--- a/src/ml4t/diagnostic/evaluation/stats/bootstrap.py
+++ b/src/ml4t/diagnostic/evaluation/stats/bootstrap.py
@@ -30,6 +30,7 @@ def stationary_bootstrap_ic(
     block_size: float | None = None,
     confidence_level: float = 0.95,
     return_details: bool = True,
+    seed: int | np.random.Generator | None = 0,
 ) -> float | dict[str, Any]:
     """Calculate p-value and confidence intervals for IC using stationary bootstrap.
 
@@ -57,6 +58,11 @@ def stationary_bootstrap_ic(
         Confidence level for the confidence interval
     return_details : bool, default=True
         If True, returns detailed results including CI and p-value
+    seed : int or np.random.Generator or None, default=0
+        Source of randomness for the resampling. The default makes a repeated
+        call on the same data return the same p-value and the same interval,
+        which is what a reader re-running a notebook needs. Pass a Generator to
+        supply your own stream, or None for a fresh unpredictable one.
 
     Returns
     -------
@@ -64,11 +70,22 @@ def stationary_bootstrap_ic(
         If return_details=False: p-value for the null hypothesis (IC=0)
         If return_details=True: Dictionary containing IC, p_value, CI, etc.
 
+    Notes
+    -----
+    Before the ``seed`` parameter existed this drew from numpy's legacy global
+    generator, so the p-value moved on every call and any decision taken against
+    a threshold moved with it. Measured on ``etfs/04_model_based_features``: two
+    consecutive production runs of identical code on identical data retained 7
+    and then 8 of 14 features under Benjamini-Hochberg at 5%, because ``ffd_lqd``
+    went p = 0.029 to p = 0.023 across the threshold.
+
     References
     ----------
     Politis, D. N., & Romano, J. P. (1994). The stationary bootstrap.
     Journal of the American Statistical Association, 89(428), 1303-1313.
     """
+    rng = seed if isinstance(seed, np.random.Generator) else np.random.default_rng(seed)
+
     # Convert to numpy arrays
     pred_array = DataFrameAdapter.to_numpy(predictions).flatten()
     ret_array = DataFrameAdapter.to_numpy(returns).flatten()
@@ -122,9 +139,9 @@ def stationary_bootstrap_ic(
 
     for i in range(n_samples):
         # Generate stationary bootstrap sample
-        boot_indices = _stationary_bootstrap_indices(n, block_size)
+        boot_indices = _stationary_bootstrap_indices(n, block_size, rng)
         # Break relationship by independently bootstrapping predictions
-        boot_pred_null = pred_clean[_stationary_bootstrap_indices(n, block_size)]
+        boot_pred_null = pred_clean[_stationary_bootstrap_indices(n, block_size, rng)]
         boot_ret = ret_clean[boot_indices]
 
         # Calculate IC on bootstrap sample
@@ -137,7 +154,7 @@ def stationary_bootstrap_ic(
     # Calculate confidence interval using percentile method
     bootstrap_ics_actual = np.zeros(n_samples)
     for i in range(n_samples):
-        boot_indices = _stationary_bootstrap_indices(n, block_size)
+        boot_indices = _stationary_bootstrap_indices(n, block_size, rng)
         boot_pred = pred_clean[boot_indices]
         boot_ret = ret_clean[boot_indices]
         ic_boot, _ = spearmanr(boot_pred, boot_ret)
@@ -160,7 +177,11 @@ def stationary_bootstrap_ic(
     }
 
 
-def _stationary_bootstrap_indices(n: int, block_size: float) -> "NDArray[np.int_]":
+def _stationary_bootstrap_indices(
+    n: int,
+    block_size: float,
+    rng: np.random.Generator,
+) -> "NDArray[np.int_]":
     """Generate indices for one stationary bootstrap sample.
 
     Parameters
@@ -169,6 +190,9 @@ def _stationary_bootstrap_indices(n: int, block_size: float) -> "NDArray[np.int_
         Sample size
     block_size : float
         Expected block size (1/p where p is the probability of ending a block)
+    rng : np.random.Generator
+        Source of randomness. Passed in rather than drawn from the module-level
+        legacy generator so a caller's result reproduces.
 
     Returns
     -------
@@ -180,9 +204,9 @@ def _stationary_bootstrap_indices(n: int, block_size: float) -> "NDArray[np.int_
 
     while len(indices) < n:
         # Start a new block at a random position
-        start_idx = np.random.randint(0, n)
+        start_idx = rng.integers(0, n)
         # Generate block length from geometric distribution
-        block_length = np.random.geometric(p)
+        block_length = rng.geometric(p)
         # Add indices from this block (with wrapping)
         for j in range(block_length):
             if len(indices) >= n:

--- a/src/ml4t/diagnostic/evaluation/stats/hac_standard_errors.py
+++ b/src/ml4t/diagnostic/evaluation/stats/hac_standard_errors.py
@@ -30,6 +30,7 @@ def robust_ic(
     returns: Union[pl.Series, pd.Series, "NDArray[Any]"],
     n_samples: int = 1000,
     return_details: bool = False,
+    seed: int | np.random.Generator | None = 0,
 ) -> dict[str, float] | float:
     """Calculate Information Coefficient with robust standard errors.
 
@@ -51,6 +52,11 @@ def robust_ic(
         Number of bootstrap samples
     return_details : bool, default False
         Whether to return detailed statistics
+    seed : int or np.random.Generator or None, default 0
+        Source of randomness for the bootstrap, forwarded to
+        ``stationary_bootstrap_ic``. The default makes a repeated call on the
+        same data return the same p-value, so a Benjamini-Hochberg count taken
+        from those p-values reproduces.
 
     Returns
     -------
@@ -72,7 +78,7 @@ def robust_ic(
            Journal of the American Statistical Association 89:1303-1313.
     """
     bootstrap_result = stationary_bootstrap_ic(
-        predictions, returns, n_samples=n_samples, return_details=True
+        predictions, returns, n_samples=n_samples, return_details=True, seed=seed
     )
     assert isinstance(bootstrap_result, dict)
 

--- a/src/ml4t/diagnostic/evaluation/stats/reality_check.py
+++ b/src/ml4t/diagnostic/evaluation/stats/reality_check.py
@@ -102,9 +102,10 @@ def whites_reality_check(
     test_statistic = np.max(mean_relative_returns)
     best_strategy_idx = np.argmax(mean_relative_returns)
 
-    # Bootstrap null distribution
-    if random_state is not None:
-        np.random.seed(random_state)
+    # Bootstrap null distribution. The generator is local: seeding numpy's global
+    # state would reach every other draw in the process, and leave the caller's
+    # stream advanced by however many blocks this happened to need.
+    rng = np.random.default_rng(random_state)
 
     # Optimal block size for stationary bootstrap (rule of thumb)
     if block_size is None:
@@ -114,7 +115,7 @@ def whites_reality_check(
 
     for _ in range(bootstrap_samples):
         # Stationary bootstrap resampling
-        bootstrap_indices = _stationary_bootstrap_indices(n_periods, float(block_size))
+        bootstrap_indices = _stationary_bootstrap_indices(n_periods, float(block_size), rng)
 
         # Resample relative returns
         bootstrap_relative = relative_returns[bootstrap_indices]

--- a/src/ml4t/diagnostic/evaluation/uncertainty.py
+++ b/src/ml4t/diagnostic/evaluation/uncertainty.py
@@ -261,22 +261,17 @@ def compute_paired_uncertainty(
     information_ratios = np.empty(n_boot)
     wins = 0
 
-    np_state = np.random.get_state()
-    np.random.seed(int(rng.integers(0, 2**31 - 1)))
-    try:
-        for i in range(n_boot):
-            idx = _stationary_bootstrap_indices(challenger_arr.size, float(block))
-            cs = _sample_stats(challenger_arr[idx], periods_per_year)
-            bs = _sample_stats(baseline_arr[idx], periods_per_year)
-            sharpe_diffs[i] = cs.sharpe - bs.sharpe
-            return_diffs[i] = cs.annualized_return - bs.annualized_return
-            max_drawdown_diffs[i] = cs.max_drawdown - bs.max_drawdown
-            information_ratios[i] = _information_ratio(
-                challenger_arr[idx] - baseline_arr[idx], periods_per_year
-            )
-            wins += int(cs.sharpe > bs.sharpe)
-    finally:
-        np.random.set_state(np_state)
+    for i in range(n_boot):
+        idx = _stationary_bootstrap_indices(challenger_arr.size, float(block), rng)
+        cs = _sample_stats(challenger_arr[idx], periods_per_year)
+        bs = _sample_stats(baseline_arr[idx], periods_per_year)
+        sharpe_diffs[i] = cs.sharpe - bs.sharpe
+        return_diffs[i] = cs.annualized_return - bs.annualized_return
+        max_drawdown_diffs[i] = cs.max_drawdown - bs.max_drawdown
+        information_ratios[i] = _information_ratio(
+            challenger_arr[idx] - baseline_arr[idx], periods_per_year
+        )
+        wins += int(cs.sharpe > bs.sharpe)
 
     sharpe_lo, sharpe_hi = _percentile_ci(sharpe_diffs, alpha)
     return_lo, return_hi = _percentile_ci(return_diffs, alpha)
@@ -428,19 +423,14 @@ def _stationary_bootstrap_metrics(
         "calmar": np.empty(n_boot),
     }
 
-    np_state = np.random.get_state()
-    np.random.seed(int(rng.integers(0, 2**31 - 1)))
-    try:
-        for i in range(n_boot):
-            sample = returns[_stationary_bootstrap_indices(returns.size, float(block_length))]
-            stats = _sample_stats(sample, periods_per_year)
-            metrics["sharpe"][i] = stats.sharpe
-            metrics["sortino"][i] = stats.sortino
-            metrics["annualized_return"][i] = stats.annualized_return
-            metrics["max_drawdown"][i] = stats.max_drawdown
-            metrics["calmar"][i] = stats.calmar
-    finally:
-        np.random.set_state(np_state)
+    for i in range(n_boot):
+        sample = returns[_stationary_bootstrap_indices(returns.size, float(block_length), rng)]
+        stats = _sample_stats(sample, periods_per_year)
+        metrics["sharpe"][i] = stats.sharpe
+        metrics["sortino"][i] = stats.sortino
+        metrics["annualized_return"][i] = stats.annualized_return
+        metrics["max_drawdown"][i] = stats.max_drawdown
+        metrics["calmar"][i] = stats.calmar
 
     return metrics
 

--- a/tests/test_evaluation/test_bootstrap_correctness.py
+++ b/tests/test_evaluation/test_bootstrap_correctness.py
@@ -29,7 +29,7 @@ class TestStationaryBootstrapIndices:
         """Bootstrap indices should have exactly n elements."""
         for n in [10, 50, 100, 500]:
             for block_size in [2, 5, 10]:
-                indices = _stationary_bootstrap_indices(n, block_size)
+                indices = _stationary_bootstrap_indices(n, block_size, np.random.default_rng(0))
 
                 assert len(indices) == n, f"Expected {n} indices, got {len(indices)}"
 
@@ -39,7 +39,7 @@ class TestStationaryBootstrapIndices:
         block_size = 5
 
         for _ in range(10):
-            indices = _stationary_bootstrap_indices(n, block_size)
+            indices = _stationary_bootstrap_indices(n, block_size, np.random.default_rng(0))
 
             assert np.all(indices >= 0), "Found negative indices"
             assert np.all(indices < n), f"Found indices >= {n}"
@@ -49,7 +49,7 @@ class TestStationaryBootstrapIndices:
         n = 100
         block_size = 10
 
-        indices = _stationary_bootstrap_indices(n, block_size)
+        indices = _stationary_bootstrap_indices(n, block_size, np.random.default_rng(0))
 
         # Find block boundaries (where diff != 1 mod n)
         diffs = np.diff(indices)
@@ -69,7 +69,7 @@ class TestStationaryBootstrapIndices:
         # Run many times to catch wrapping behavior
         saw_wrap = False
         for _ in range(100):
-            indices = _stationary_bootstrap_indices(n, block_size)
+            indices = _stationary_bootstrap_indices(n, block_size, np.random.default_rng(0))
 
             # Check for wrap: a block starting at e.g. index 18 should wrap to 0, 1, 2...
             for i in range(len(indices) - 1):
@@ -93,7 +93,7 @@ class TestStationaryBootstrapIndices:
         all_block_lengths = []
 
         for _ in range(100):
-            indices = _stationary_bootstrap_indices(n, block_size)
+            indices = _stationary_bootstrap_indices(n, block_size, np.random.default_rng(0))
 
             # Find block lengths by detecting boundaries
             diffs = np.diff(indices)
@@ -253,20 +253,67 @@ class TestStationaryBootstrapIC:
         assert isinstance(result, float), f"Expected float, got {type(result)}"
         assert 0 <= result <= 1, f"P-value {result} out of bounds"
 
-    def test_reproducibility(self):
-        """Results should be reproducible with numpy seed before call."""
-        predictions = np.random.randn(50)
-        returns = predictions * 0.3 + np.random.randn(50) * 0.5
+    def test_reproducible_without_the_caller_seeding_anything(self):
+        """Two calls on the same data return the same p-value and the same interval.
 
-        np.random.seed(42)
-        result1 = stationary_bootstrap_ic(predictions, returns, n_samples=100)
+        The caller seeds nothing. That is the point: the function used to draw
+        from numpy's legacy global generator, so it reproduced only when its
+        caller happened to reseed the process first, and a notebook that did not
+        printed a different p-value on every run. Measured downstream on
+        etfs/04_model_based_features, two consecutive production executions of
+        identical code on identical data retained 7 and then 8 of 14 features
+        under Benjamini-Hochberg at 5%.
+        """
+        rng = np.random.default_rng(11)
+        predictions = rng.normal(size=80)
+        returns = predictions * 0.3 + rng.normal(size=80) * 0.5
 
-        np.random.seed(42)
-        result2 = stationary_bootstrap_ic(predictions, returns, n_samples=100)
+        first = stationary_bootstrap_ic(predictions, returns, n_samples=100)
+        second = stationary_bootstrap_ic(predictions, returns, n_samples=100)
 
-        assert result1["p_value"] == result2["p_value"], "Results not reproducible"
-        assert result1["ci_lower"] == result2["ci_lower"]
-        assert result1["ci_upper"] == result2["ci_upper"]
+        assert first["p_value"] == second["p_value"]
+        assert first["ci_lower"] == second["ci_lower"]
+        assert first["ci_upper"] == second["ci_upper"]
+
+    def test_the_global_generator_cannot_change_the_answer(self):
+        """Whatever else in the process has drawn from numpy, the answer is the same."""
+        rng = np.random.default_rng(11)
+        predictions = rng.normal(size=80)
+        returns = predictions * 0.3 + rng.normal(size=80) * 0.5
+
+        np.random.seed(1)
+        first = stationary_bootstrap_ic(predictions, returns, n_samples=100)
+        np.random.seed(999)
+        np.random.random(1234)  # advance the global stream by an arbitrary amount
+        second = stationary_bootstrap_ic(predictions, returns, n_samples=100)
+
+        assert first == second
+
+    def test_a_different_seed_gives_a_different_draw(self):
+        """The default is a choice of stream, not a hardcoded answer."""
+        rng = np.random.default_rng(11)
+        predictions = rng.normal(size=80)
+        returns = predictions * 0.3 + rng.normal(size=80) * 0.5
+
+        default = stationary_bootstrap_ic(predictions, returns, n_samples=200)
+        other = stationary_bootstrap_ic(predictions, returns, n_samples=200, seed=7)
+
+        assert default["ic"] == other["ic"], "the observed IC is not a bootstrap quantity"
+        assert (default["ci_lower"], default["ci_upper"]) != (
+            other["ci_lower"],
+            other["ci_upper"],
+        )
+
+    def test_robust_ic_reproduces_the_p_value_it_reports(self):
+        """The BH-retained feature count is computed from these p-values."""
+        from ml4t.diagnostic.evaluation.stats import robust_ic
+
+        rng = np.random.default_rng(3)
+        x = rng.normal(size=400)
+        y = 0.05 * x + rng.normal(size=400)
+
+        p_values = [robust_ic(x, y, return_details=True)["p_value"] for _ in range(3)]
+        assert len(set(p_values)) == 1, f"p-value moved across identical calls: {p_values}"
 
 
 class TestBootstrapStatisticalProperties:

--- a/tests/test_evaluation/test_stats.py
+++ b/tests/test_evaluation/test_stats.py
@@ -1219,7 +1219,7 @@ class TestStationaryBootstrapIndices:
         from ml4t.diagnostic.evaluation.stats import _stationary_bootstrap_indices
 
         np.random.seed(42)
-        indices = _stationary_bootstrap_indices(100, 10.0)
+        indices = _stationary_bootstrap_indices(100, 10.0, np.random.default_rng(0))
 
         assert len(indices) == 100
         assert all(0 <= idx < 100 for idx in indices)
@@ -1229,7 +1229,7 @@ class TestStationaryBootstrapIndices:
         from ml4t.diagnostic.evaluation.stats import _stationary_bootstrap_indices
 
         np.random.seed(42)
-        indices = _stationary_bootstrap_indices(50, 2.0)
+        indices = _stationary_bootstrap_indices(50, 2.0, np.random.default_rng(0))
 
         assert len(indices) == 50
 


### PR DESCRIPTION
`_stationary_bootstrap_indices` drew its block starts and block lengths from numpy's legacy global generator, so `stationary_bootstrap_ic` and `robust_ic` returned a different p-value on every call unless the caller happened to reseed the process first.

Three identical calls on identical data:

```
p-value moved across identical calls: [0.679, 0.668, 0.647]
```

Anything computed from those p-values moved with them. Measured downstream in the book repo, on two consecutive production executions of `etfs/04_model_based_features` with identical code and identical data: 7 and then 8 of 14 features retained under Benjamini-Hochberg at 5%, because `ffd_lqd` went p = 0.029 to p = 0.023 across the threshold. A reader re-running the notebook did not reproduce the committed count.

## The change

The generator is a parameter. `_stationary_bootstrap_indices` takes an `np.random.Generator`; `stationary_bootstrap_ic` and `robust_ic` take `seed: int | Generator | None = 0` and forward it. The observed IC is unaffected, being no part of the bootstrap; the interval and the p-value become a fixed draw rather than a fresh one.

The two other callers of the index helper seeded by mutating process-global state - `np.random.get_state()`, `np.random.seed(derived)`, and a `try/finally` to put it back. That reaches every other draw in the process for as long as it is set, and races anything concurrent. `uncertainty._stationary_bootstrap_metrics`, `compute_paired_uncertainty` and `whites_reality_check` now pass the `Generator` they already had.

## Numbers that move

Any caller of `whites_reality_check`, `compute_paired_uncertainty` or `compute_backtest_uncertainty` at a fixed seed. They were reproducible before and are reproducible now, at different values, because a `Generator` draws a different stream from the legacy `RandomState`. No caller of `robust_ic` had a stable value to move.

## Tests

The previous reproducibility test seeded `np.random` before each of its two calls, so it passed against the defect: it measured that seeding the global works, not that the function reproduces. It now calls twice with the caller seeding nothing. Three more cover an arbitrarily advanced global stream not changing the answer, a different seed giving a different interval while the observed IC holds, and `robust_ic` returning one p-value across three calls. All four fail against the previous implementation.

Pre-existing in this worktree and unrelated: 23 SHAP tests in `test_metrics.py` and `test_shap_interactions.py` fail with these changes stashed.

Closes #40