### PR TITLE
release: 0.1.1

### DIFF
--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # Sub-modules for advanced usage
 from . import (


### PR DESCRIPTION
Bumps `__version__` to 0.1.1 so the release tag builds the version it names.

`[tool.hatch.version]` reads `path = "src/ml4t/diagnostic/__init__.py"`, not the git tag, so tagging alone rebuilds the previous version. The first `v0.1.1` tag did exactly that: every test and audit job passed, `Build Package` produced `ml4t_diagnostic-0.1.0`, and `Publish to PyPI` failed with `400 File already exists`. The tag has been deleted and will be recreated on this commit.

0.1.1 carries #34: the session grid derived from the timestamp span rather than the endpoints, and `missing="conservative"` reaching statsmodels with its gaps intact.

Worth considering separately: `ml4t-engineer` uses `source = "vcs"` and derives its version from the tag, so this class of failure cannot happen there. Aligning the two would remove the manual step.