### PR TITLE
fix: report an undefined cross-sectional IC as null, not NaN (release 0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ml4t-diagnostic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-08-17
+
+### Fixed
+- **Undefined cross-sectional IC is null, not NaN**: `cross_sectional_ic_series()`
+  returned NaN for a date where all predictions or all returns are tied and the
+  correlation is therefore undefined. Polars treats NaN and null as different
+  values, so `drop_nulls("ic").mean()` kept the NaN and the mean came back NaN.
+  Such a date now carries null, matching what the `min_obs` gate already did and
+  what `cross_sectional_ic()` already reported in `n_periods`.
+
+## [0.1.1] - 2026-08-11
+
+### Fixed
+- **Session grid for unordered timestamps** and a **gap-preserving
+  `missing="conservative"` ACF**.
+
 ## [0.1.0b21] - 2026-05-15
 
 ### Fixed

--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 # Sub-modules for advanced usage
 from . import (

--- a/src/ml4t/diagnostic/metrics/ic.py
+++ b/src/ml4t/diagnostic/metrics/ic.py
@@ -210,7 +210,10 @@ def cross_sectional_ic_series(
     Returns
     -------
     Union[pl.DataFrame, pd.DataFrame]
-        Time series of IC values with columns: [date_col, 'ic', 'n_obs']
+        Time series of IC values with columns: [date_col, 'ic', 'n_obs'].
+        A date whose IC is undefined - fewer than ``min_obs`` valid
+        observations, or all predictions or all returns tied so the
+        correlation denominator is zero - carries a null `ic`, never a NaN.
 
     Examples
     --------
@@ -283,8 +286,7 @@ def cross_sectional_ic_series(
         p_col, r_col = "__pred_valid", "__ret_valid"
 
     # Preserve every date present in the join, even those where all rows
-    # were invalid (matches the old per-group behavior of emitting a row
-    # with n_obs=0 and ic=NaN).
+    # were invalid; such a date gets n_obs=0 and a null IC.
     all_dates = df.select(date_col).unique().sort(date_col)
     grouped = df_valid.group_by(date_col, maintain_order=False).agg(
         [
@@ -292,12 +294,20 @@ def cross_sectional_ic_series(
             pl.corr(pl.col(p_col), pl.col(r_col)).alias("ic"),
         ]
     )
+    # A date the correlation is undefined for - all predictions or all returns
+    # tied, so the denominator is zero - comes back from pl.corr as NaN. Report
+    # it as null, the same as a date below min_obs: polars treats NaN and null
+    # as different values, and a NaN that survives drop_nulls poisons every
+    # downstream mean.
     ic_series_pl = (
         all_dates.join(grouped, on=date_col, how="left")
         .with_columns(
             [
                 pl.col("n_obs").fill_null(0),
-                pl.when(pl.col("n_obs") >= min_obs).then(pl.col("ic")).otherwise(None).alias("ic"),
+                pl.when((pl.col("n_obs") >= min_obs) & pl.col("ic").is_finite())
+                .then(pl.col("ic"))
+                .otherwise(None)
+                .alias("ic"),
             ]
         )
         .sort(date_col)

--- a/tests/test_evaluation/test_information_coefficient.py
+++ b/tests/test_evaluation/test_information_coefficient.py
@@ -435,6 +435,82 @@ class TestComputeICSeries:
         ic_values = result["ic"].to_numpy()
         assert all(np.isnan(ic_values))
 
+    @staticmethod
+    def _panel_with_one_tied_date(tied_col: str) -> tuple[pl.DataFrame, pl.DataFrame]:
+        """Three dates of 12 symbols where the middle date ties `tied_col`."""
+        rng = np.random.default_rng(0)
+        dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+        symbols = [f"S{i:02d}" for i in range(12)]
+
+        rows = []
+        for d in dates:
+            tied = d == "2024-01-02"
+            preds = np.full(12, 0.5) if tied and tied_col == "prediction" else rng.normal(size=12)
+            rets = (
+                np.zeros(12)
+                if tied and tied_col == "forward_return"
+                else rng.normal(size=12) * 0.02
+            )
+            for symbol, pred, ret in zip(symbols, preds, rets):
+                rows.append(
+                    {
+                        "date": d,
+                        "symbol": symbol,
+                        "prediction": float(pred),
+                        "forward_return": float(ret),
+                    }
+                )
+
+        df = pl.DataFrame(rows)
+        return df.select(["date", "symbol", "prediction"]), df.select(
+            ["date", "symbol", "forward_return"]
+        )
+
+    @pytest.mark.parametrize("tied_col", ["prediction", "forward_return"])
+    @pytest.mark.parametrize("method", ["spearman", "pearson"])
+    def test_undefined_date_is_null_not_nan(self, tied_col, method):
+        """A date whose correlation is undefined gets null, so means stay finite.
+
+        Spearman and Pearson are both undefined when one side has zero variance.
+        Polars distinguishes NaN from null, so a NaN here survives drop_nulls and
+        turns every downstream mean into NaN (issue #493).
+        """
+        pred_df, ret_df = self._panel_with_one_tied_date(tied_col)
+
+        result = cross_sectional_ic_series(
+            pred_df,
+            ret_df,
+            pred_col="prediction",
+            ret_col="forward_return",
+            entity_col="symbol",
+            method=method,
+            min_obs=10,
+        )
+
+        assert result["ic"].null_count() == 1
+        assert result["ic"].is_nan().sum() == 0
+        assert result["n_obs"].to_list() == [12, 12, 12]
+
+        mean_ic = result.drop_nulls("ic")["ic"].mean()
+        assert mean_ic is not None
+        assert np.isfinite(mean_ic)
+
+    def test_undefined_date_excluded_from_aggregate(self):
+        """The aggregate wrapper counts a tied date as missing, not as zero IC."""
+        pred_df, ret_df = self._panel_with_one_tied_date("prediction")
+
+        summary = cross_sectional_ic(
+            pred_df,
+            ret_df,
+            pred_col="prediction",
+            ret_col="forward_return",
+            entity_col="symbol",
+            min_obs=10,
+        )
+
+        assert summary["n_periods"] == 2
+        assert np.isfinite(summary["ic_mean"])
+
     def test_ic_series_pearson_method(self, sample_data_polars):
         """Test IC series with Pearson correlation."""
         pred_df, ret_df = sample_data_polars


### PR DESCRIPTION
Closes #43.

## The fix

`cross_sectional_ic_series()` builds its per-date IC with `pl.corr` over ranks.
The correlation is undefined when one side of a date has zero variance - every
prediction tied, or every return tied - and `pl.corr` returns NaN. Polars treats
NaN and null as different values, so the NaN survives `drop_nulls("ic")` and the
caller's mean IC comes back `nan` with nothing raising.

The correlation is now gated on `is_finite()` alongside `min_obs`, so an
undefined date carries null - the same as a date below `min_obs`, and the same
as what `cross_sectional_ic()` already reported in `n_periods`.

Verified end to end against the published 0.1.1 wheel with the issue's
reproducer:

| | 0.1.1 | this branch |
|---|---|---|
| `ic` on the tied date | `NaN` | `null` |
| `drop_nulls("ic").mean()` | `nan` | `0.244755` |
| `n_periods` | 2 | 2 |

Four new tests cover both correlation methods against both tied sides, asserting
`null_count() == 1` and `is_nan().sum() == 0`. All four fail when the
`is_finite()` gate is removed.

## Release 0.1.2

`[tool.hatch.version]` reads `__version__` from
`src/ml4t/diagnostic/__init__.py`, not from the git tag, so the bump has to land
on a commit before `v0.1.2` is tagged - tagging alone would rebuild 0.1.1 and
PyPI would reject the upload as a duplicate. That is what happened to the first
`v0.1.1` tag.

The CHANGELOG had no 0.1.1 entry; one is added from that release commit so the
file does not jump 0.1.0b21 -> 0.1.2.

## Local verification

`ruff check`, `ruff format --check`, and `ty check` clean; 5331 passed, 75
skipped. `uv build` plus `scripts/verify_release_artifacts.py` and
`scripts/import_smoke.py` pass against the built 0.1.2 wheel.
