### PR TITLE
fix: recentre White's Reality Check on the sample means, not on each bootstrap draw

### DIFF
--- a/src/ml4t/diagnostic/evaluation/stats/reality_check.py
+++ b/src/ml4t/diagnostic/evaluation/stats/reality_check.py
@@ -118,13 +118,13 @@ def whites_reality_check(
         bootstrap_indices = _stationary_bootstrap_indices(n_periods, float(block_size), rng)
 
         # Resample relative returns
-        bootstrap_relative = relative_returns[bootstrap_indices]
+        bootstrap_means = np.mean(relative_returns[bootstrap_indices], axis=0)
 
-        # Center the bootstrap sample (impose null hypothesis)
-        bootstrap_relative = bootstrap_relative - np.mean(bootstrap_relative, axis=0)
-
-        # Calculate maximum mean for this bootstrap sample
-        bootstrap_max = np.max(np.mean(bootstrap_relative, axis=0))
+        # Impose the null by recentring on the ORIGINAL sample means, as in White
+        # (2000), p. 1105: V*_l = max_k n^(1/2) (f*_k - f_k). Subtracting the bootstrap
+        # sample's own means instead drives every column mean to zero, so the null
+        # collapses onto float error and the test rejects for any positive statistic.
+        bootstrap_max = np.max(bootstrap_means - mean_relative_returns)
         null_dist_list.append(float(bootstrap_max))
 
     null_distribution = np.array(null_dist_list)

--- a/tests/test_evaluation/test_stats.py
+++ b/tests/test_evaluation/test_stats.py
@@ -1456,6 +1456,112 @@ class TestWhitesRealityCheck:
         assert result["critical_values"]["90%"] <= result["critical_values"]["95%"]
         assert result["critical_values"]["95%"] <= result["critical_values"]["99%"]
 
+    def test_whites_reality_check_null_distribution_is_not_degenerate(self):
+        """The null must be resampled around the sample means, not around itself.
+
+        Recentring each bootstrap draw on its OWN column means sets every column mean
+        to exactly zero, so the null collapses onto machine epsilon and carries no
+        information about sampling variability.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(0)
+        n_periods = 252
+        returns = rng.normal(0.0, 0.02, n_periods)
+
+        result = whites_reality_check(
+            returns_benchmark=np.zeros(n_periods),
+            returns_strategies=returns.reshape(-1, 1),
+            bootstrap_samples=500,
+            random_state=42,
+        )
+
+        # The null is a sampling distribution of a mean, so its spread must be a
+        # meaningful fraction of that mean's standard error rather than float noise.
+        standard_error = returns.std(ddof=1) / np.sqrt(n_periods)
+        assert result["null_distribution"].std() > 0.1 * standard_error
+
+    def test_whites_reality_check_pvalue_is_not_the_sign_of_the_mean(self):
+        """A single strategy inside the noise must not come back certain either way.
+
+        With a degenerate null every draw ties at zero, so the p-value is 1.0 when the
+        test statistic is negative and 0.0 the moment it turns positive -- the sign of
+        the sample mean wearing a p-value's name.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(7)
+        n_periods = 252
+        returns = rng.normal(0.0, 0.02, n_periods)
+        # Nudge the sample mean positive by a fraction of its own standard error.
+        returns = returns - returns.mean() + 0.2 * returns.std(ddof=1) / np.sqrt(n_periods)
+        assert returns.mean() > 0
+
+        result = whites_reality_check(
+            returns_benchmark=np.zeros(n_periods),
+            returns_strategies=returns.reshape(-1, 1),
+            bootstrap_samples=1000,
+            random_state=42,
+        )
+
+        assert 0.05 < result["p_value"] < 0.95
+
+    def test_whites_reality_check_size_with_many_strategies(self):
+        """The test must not reject on strategies that have no edge at all.
+
+        This is the property the Reality Check exists for, and the one a single
+        strategy cannot exercise: with the null recentred on each bootstrap draw
+        instead of on the sample means, 30 pure-noise strategies are declared
+        significant on essentially every draw.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(11)
+        n_trials, n_periods, n_strategies = 150, 252, 30
+
+        rejections = 0
+        for _ in range(n_trials):
+            benchmark = rng.normal(0.0, 0.02, n_periods)
+            strategies = rng.normal(0.0, 0.02, (n_periods, n_strategies))
+            result = whites_reality_check(
+                returns_benchmark=benchmark,
+                returns_strategies=strategies,
+                bootstrap_samples=200,
+                random_state=int(rng.integers(1_000_000_000)),
+            )
+            rejections += result["p_value"] < 0.05
+
+        # Nominal is 7.5 of 150. The bound is deliberately loose -- it is here to
+        # catch a broken null, not to pin the bootstrap's finite-sample size.
+        assert rejections <= 20
+
+    def test_whites_reality_check_finds_a_real_edge_among_many_strategies(self):
+        """The other half of the size test: a null that is too wide sees nothing.
+
+        Recentring on a single summary of the sample means rather than on each
+        column's own mean passes the size test by never rejecting at all, so the
+        two are only meaningful together.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(23)
+        n_trials, n_periods, n_strategies = 60, 252, 30
+
+        detections = 0
+        for _ in range(n_trials):
+            benchmark = rng.normal(0.0, 0.02, n_periods)
+            strategies = rng.normal(0.0, 0.02, (n_periods, n_strategies))
+            strategies[:, 0] += 0.01  # ~0.63 standard errors per period
+            result = whites_reality_check(
+                returns_benchmark=benchmark,
+                returns_strategies=strategies,
+                bootstrap_samples=200,
+                random_state=int(rng.integers(1_000_000_000)),
+            )
+            detections += result["p_value"] < 0.05
+
+        assert detections >= 45
+
 
 class TestMultipleTestingSummary:
     """Tests for multiple_testing_summary function."""


### PR DESCRIPTION
## Owning issue

Closes #46

## Outcome

`Evaluator(statistical_tests=["whites_reality_check"], tier=2)`, run on a target generated with no
relationship to the features at all:

| | `p_value` | `critical_values["95%"]` |
|---|---|---|
| `main` | **0.000** | 3.04e-19 |
| with this patch | 0.372 | 5.62e-04 |

The test statistic is the same in both rows (1.40e-04). Only the null it is compared against changes.

## Where it comes from

`whites_reality_check` imposes the null by subtracting each bootstrap sample's **own** column means
from itself:

```python
bootstrap_relative = relative_returns[bootstrap_indices]
bootstrap_relative = bootstrap_relative - np.mean(bootstrap_relative, axis=0)
bootstrap_max = np.max(np.mean(bootstrap_relative, axis=0))
```

After that subtraction each column mean is zero up to float error, so `bootstrap_max` is float error
rather than a resampled statistic. On a 252-period, 30-strategy input the null comes back
`min=7.0e-19  max=1.5e-17  std=2.0e-18`, and the 90/95/99% critical values are 6.4e-18, 7.9e-18 and
1.0e-17.

With the null a point mass at float error, `p_value = np.mean(null_distribution >= test_statistic)`
reduces to the **sign of the test statistic**. Over 300 draws of 30 pure-noise strategies against a
pure-noise benchmark, `p_value < 0.05` and `test_statistic > 0` agreed on **300 of 300** trials, and
`p_value` took exactly two values, 0.0 and 1.0.

That fixes the false-positive rate by arithmetic rather than by evidence. The best of 30 exchangeable
series beats a 31st with probability 30/31 = **96.8%** (200,000-draw check: 0.96727); with one
strategy against a zero benchmark the corresponding rate is 1/2. Both are what `main` returns, and
neither has anything to do with the data.

The single-strategy case is not hypothetical: `evaluation/framework.py:818-837` concatenates a run's
OOS returns and passes them as one column against a zero benchmark, which is the path the table at
the top goes through.

## The change

White (2000) recentres each resample on the **original** sample means: for models k = 1…l,
`V*_l = max_k n^(1/2) ( f̄*_k − f̄_k )` (p. 1105). That is the whole diff — the scaling cancels
between statistic and null, so only the recentring is at issue.

Rejection rates at the nominal 5%, on data with no edge in it. 1,000 trials per cell, pooled over
four independent seeds, same protocol on both branches:

| Input, no true edge present | `main` | with this patch |
|---|---|---|
| 30 strategies vs a noise benchmark | 962/1000 = 0.962, Wilson [0.948, 0.972] | **60/1000 = 0.060**, [0.047, 0.077] |
| One strategy vs a zero benchmark | 504/1000 = 0.504, [0.473, 0.535] | **48/1000 = 0.048**, [0.036, 0.063] |

Both `main` columns sit on their arithmetic values (30/31 and 1/2) and neither patched column
excludes 0.05.

⚠ **That is iid data, and the fix does not make the test nominal everywhere.** The block size at
line 111 is `max(1, int(n ** (1/3)))` regardless of the data, so under serial dependence the
corrected test is still oversized. Both branches, n=252, 300 trials per cell:

| H0 data | K=1 | K=5 | K=30 |
|---|---|---|---|
| iid | 0.067 | 0.060 | 0.067 |
| AR(1) φ=0.6 | 0.093 | 0.113 | 0.140 |
| AR(1) φ=0.9 | 0.187 | 0.297 | 0.377 |
| overlapping 21-period returns | 0.200 | 0.260 | 0.380 |
| *`main`, all four data types* | *0.49–0.56* | *0.81–0.86* | *0.97–0.99* |

`main`'s row does not move with the data at all, because its rejection rate is K/(K+1) — the chance
that the best of K exchangeable series beats a (K+1)th, and it does not move with the dependence
structure anywhere in this table.
So the patch improves every cell; the honest claim is that it restores nominal size under weak
dependence and leaves a block-length problem under strong persistence, which is a separate question
from this one.

## Why the existing tests do not catch it

The seven tests in `TestWhitesRealityCheck` assert the result's shape — that it is a dict, that
`0 <= p_value <= 1`, that the percentiles are ordered, that a strategy with +5%/period alpha lands
`p < 0.5`. All seven pass with a degenerate null. Four are added here that do not:

- `..._null_distribution_is_not_degenerate` — the null's spread must be a meaningful fraction of the
  standard error of the mean it is a sampling distribution of.
- `..._pvalue_is_not_the_sign_of_the_mean` — a single strategy nudged 0.2 standard errors positive
  must not come back certain. It returns exactly 0.0 on `main`.
- `..._size_with_many_strategies` — 30 strategies with no edge, 150 trials, at most 20 rejections
  against a nominal 7.5. This is the property a single-strategy input does not exercise, and the one
  the Reality Check exists for. `main` rejects 143-148 times out of 150.
- `..._finds_a_real_edge_among_many_strategies` — its other half. A null that is too *wide* passes a
  size test by rejecting almost nothing, so one strategy carrying 0.63 standard errors per period
  among 30 must be found in at least 45 of 60 trials.

The last two cost ~5.8s together.

Restoring the two original lines at the defect site fails three of the four and leaves the seven
passing. Three further wrong centrings, each restored at that same site, are also caught: omitting
the recentring (caught by your `..._with_outperformer` and by the new power test),
`np.max(bootstrap_means) - np.max(mean_relative_returns)` (sized at 0.25, caught by the size test),
and recentring on the grand mean of the sample means (caught by the power test). One is not:
subtracting one column's mean from every column still passes all eleven, because on exchangeable
inputs it is neither oversized nor underpowered.

`tests/test_evaluation/test_stats.py` goes from 130 to 134 passed. Across
`tests/test_evaluation tests/test_integration tests/validation tests/test_core tests/metrics` the run
goes from `97 failed, 2916 passed, 6 errors` to `97 failed, 2920 passed, 6 errors`, and the 97 failing
node ids match line for line between the two trees rather than merely in count. Those failures and
the six module-level collection errors are `shap` (45 occurrences), `plotly` (11) and a missing
`ml4t.backtest` (2) in this environment; none of them is in `test_stats.py`.

One thing noticed and deliberately left alone: `p_value` uses `np.mean(null_distribution >=
test_statistic)`, so it can return exactly `0.0` — a modest alternative produces it about half the
time. `(1 + #{V* >= V}) / (B + 1)` would floor it at `1/(B+1)`. That is a separate one-line decision
and I did not want to fold it into a correctness fix.


## Compatibility

- [x] No public compatibility impact

The signature, the returned keys and their types are unchanged. `p_value`, `critical_values` and
`null_distribution` now carry different values, which is the point of the fix.

## Verification

- [x] Tests reproduce the prior failure or verify the requested behavior
- [x] Ruff lint and format checks pass
- [x] `ty` passes
- [x] Test suite passes
- [ ] Package build passes when applicable — not run
- [ ] Strict MkDocs build passes when documentation is affected — no documentation changed
- [ ] Ecosystem qualification passes — not run

`ruff check`, `ruff format --check` and `ty check` are clean on both changed files. My environment is
missing `shap`, `plotly` and `ml4t.backtest`, so 97 tests and 6 module-level collection errors fail
in it on `main` as well; the 97 failing node ids match line for line before and after this change.

## Documentation and release

`whites_reality_check`'s docstring describes the test, not its numbers, so nothing there goes stale.
Release notes would want a line saying the p-value changes for existing callers — anyone who recorded
a `p = 0.000` from this function will get a different number, and in most cases a much larger one.
