### PR TITLE
fix: center White's Reality Check on the sample means

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ viz = [
     "matplotlib>=3.7.0",
     "seaborn>=0.12.0",
     "kaleido>=0.2.0",  # For plotly PDF export
-    "pypdf>=6.14.2",    # For PDF merging
+    "pypdf>=6.16.1",    # For PDF merging
 ]
 
 # Additional ML model backends
@@ -176,7 +176,7 @@ all = [
     "matplotlib>=3.7.0",
     "seaborn>=0.12.0",
     "kaleido>=0.2.0",
-    "pypdf>=6.14.2",
+    "pypdf>=6.16.1",
     "lightgbm>=4.0.0",
     "xgboost>=2.0.0",
     "numba>=0.62.0; python_version < '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin'",
@@ -205,7 +205,7 @@ test = [
     "matplotlib>=3.7.0",
     "seaborn>=0.12.0",
     "kaleido>=0.2.0",
-    "pypdf>=6.14.2",
+    "pypdf>=6.16.1",
     "ml4t-backtest>=0.1.0b10",
 ]
 dev = [

--- a/src/ml4t/diagnostic/evaluation/stats/reality_check.py
+++ b/src/ml4t/diagnostic/evaluation/stats/reality_check.py
@@ -118,13 +118,13 @@ def whites_reality_check(
         bootstrap_indices = _stationary_bootstrap_indices(n_periods, float(block_size), rng)
 
         # Resample relative returns
-        bootstrap_relative = relative_returns[bootstrap_indices]
+        bootstrap_means = np.mean(relative_returns[bootstrap_indices], axis=0)
 
-        # Center the bootstrap sample (impose null hypothesis)
-        bootstrap_relative = bootstrap_relative - np.mean(bootstrap_relative, axis=0)
-
-        # Calculate maximum mean for this bootstrap sample
-        bootstrap_max = np.max(np.mean(bootstrap_relative, axis=0))
+        # Impose the null by recentring on the ORIGINAL sample means, as in White
+        # (2000), p. 1105: V*_l = max_k n^(1/2) (f*_k - f_k). Subtracting the bootstrap
+        # sample's own means instead drives every column mean to zero, so the null
+        # collapses onto float error and the test rejects for any positive statistic.
+        bootstrap_max = np.max(bootstrap_means - mean_relative_returns)
         null_dist_list.append(float(bootstrap_max))
 
     null_distribution = np.array(null_dist_list)

--- a/tests/test_evaluation/test_stats.py
+++ b/tests/test_evaluation/test_stats.py
@@ -1456,6 +1456,112 @@ class TestWhitesRealityCheck:
         assert result["critical_values"]["90%"] <= result["critical_values"]["95%"]
         assert result["critical_values"]["95%"] <= result["critical_values"]["99%"]
 
+    def test_whites_reality_check_null_distribution_is_not_degenerate(self):
+        """The null must be resampled around the sample means, not around itself.
+
+        Recentring each bootstrap draw on its OWN column means sets every column mean
+        to exactly zero, so the null collapses onto machine epsilon and carries no
+        information about sampling variability.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(0)
+        n_periods = 252
+        returns = rng.normal(0.0, 0.02, n_periods)
+
+        result = whites_reality_check(
+            returns_benchmark=np.zeros(n_periods),
+            returns_strategies=returns.reshape(-1, 1),
+            bootstrap_samples=500,
+            random_state=42,
+        )
+
+        # The null is a sampling distribution of a mean, so its spread must be a
+        # meaningful fraction of that mean's standard error rather than float noise.
+        standard_error = returns.std(ddof=1) / np.sqrt(n_periods)
+        assert result["null_distribution"].std() > 0.1 * standard_error
+
+    def test_whites_reality_check_pvalue_is_not_the_sign_of_the_mean(self):
+        """A single strategy inside the noise must not come back certain either way.
+
+        With a degenerate null every draw ties at zero, so the p-value is 1.0 when the
+        test statistic is negative and 0.0 the moment it turns positive -- the sign of
+        the sample mean wearing a p-value's name.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(7)
+        n_periods = 252
+        returns = rng.normal(0.0, 0.02, n_periods)
+        # Nudge the sample mean positive by a fraction of its own standard error.
+        returns = returns - returns.mean() + 0.2 * returns.std(ddof=1) / np.sqrt(n_periods)
+        assert returns.mean() > 0
+
+        result = whites_reality_check(
+            returns_benchmark=np.zeros(n_periods),
+            returns_strategies=returns.reshape(-1, 1),
+            bootstrap_samples=1000,
+            random_state=42,
+        )
+
+        assert 0.05 < result["p_value"] < 0.95
+
+    def test_whites_reality_check_size_with_many_strategies(self):
+        """The test must not reject on strategies that have no edge at all.
+
+        This is the property the Reality Check exists for, and the one a single
+        strategy cannot exercise: with the null recentred on each bootstrap draw
+        instead of on the sample means, 30 pure-noise strategies are declared
+        significant on essentially every draw.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(11)
+        n_trials, n_periods, n_strategies = 150, 252, 30
+
+        rejections = 0
+        for _ in range(n_trials):
+            benchmark = rng.normal(0.0, 0.02, n_periods)
+            strategies = rng.normal(0.0, 0.02, (n_periods, n_strategies))
+            result = whites_reality_check(
+                returns_benchmark=benchmark,
+                returns_strategies=strategies,
+                bootstrap_samples=200,
+                random_state=int(rng.integers(1_000_000_000)),
+            )
+            rejections += result["p_value"] < 0.05
+
+        # Nominal is 7.5 of 150. The bound is deliberately loose -- it is here to
+        # catch a broken null, not to pin the bootstrap's finite-sample size.
+        assert rejections <= 20
+
+    def test_whites_reality_check_finds_a_real_edge_among_many_strategies(self):
+        """The other half of the size test: a null that is too wide sees nothing.
+
+        Recentring on a single summary of the sample means rather than on each
+        column's own mean passes the size test by never rejecting at all, so the
+        two are only meaningful together.
+        """
+        from ml4t.diagnostic.evaluation.stats import whites_reality_check
+
+        rng = np.random.default_rng(23)
+        n_trials, n_periods, n_strategies = 60, 252, 30
+
+        detections = 0
+        for _ in range(n_trials):
+            benchmark = rng.normal(0.0, 0.02, n_periods)
+            strategies = rng.normal(0.0, 0.02, (n_periods, n_strategies))
+            strategies[:, 0] += 0.01  # ~0.63 standard errors per period
+            result = whites_reality_check(
+                returns_benchmark=benchmark,
+                returns_strategies=strategies,
+                bootstrap_samples=200,
+                random_state=int(rng.integers(1_000_000_000)),
+            )
+            detections += result["p_value"] < 0.05
+
+        assert detections >= 45
+
 
 class TestMultipleTestingSummary:
     """Tests for multiple_testing_summary function."""

--- a/uv.lock
+++ b/uv.lock
@@ -1861,8 +1861,8 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.3.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
-    { name = "pypdf", marker = "extra == 'all'", specifier = ">=6.14.2" },
-    { name = "pypdf", marker = "extra == 'viz'", specifier = ">=6.14.2" },
+    { name = "pypdf", marker = "extra == 'all'", specifier = ">=6.16.1" },
+    { name = "pypdf", marker = "extra == 'viz'", specifier = ">=6.16.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
@@ -1896,7 +1896,7 @@ dev = [
     { name = "pip-audit", specifier = ">=2.10.1" },
     { name = "plotly", specifier = ">=5.15.0" },
     { name = "pre-commit", specifier = ">=3.3.0" },
-    { name = "pypdf", specifier = ">=6.14.2" },
+    { name = "pypdf", specifier = ">=6.16.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -1915,7 +1915,7 @@ test = [
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "ml4t-backtest", specifier = ">=0.1.0b10" },
     { name = "plotly", specifier = ">=5.15.0" },
-    { name = "pypdf", specifier = ">=6.14.2" },
+    { name = "pypdf", specifier = ">=6.16.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -3024,11 +3024,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.15.0"
+version = "6.16.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload-time = "2026-08-23T13:50:07.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload-time = "2026-08-23T13:50:05.349Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #46.

This carries the correction and regression tests from #47, preserving Zorion Arrillaga as the commit author, on top of current `main`. It also raises the optional `pypdf` floor to 6.16.1 and locks 6.16.2 because the local security gate found CVE-2026-84309, CVE-2026-84310, and CVE-2026-84311 in 6.15.0.

Verified locally on Python 3.14:
- public-API reproduction fails on `main` and no longer degenerates with this fix
- 5,391 tests passed, 21 skipped
- focused White Reality Check and PDF tests: 34 passed
- Ruff, ty, seeded property tests, benchmark suite, package build/import, MkDocs strict, and pre-commit passed
- PyPI advisory audit reports no known vulnerabilities

Supersedes #47 without losing its authorship or test coverage.