### PR TITLE
fix: emit backward CV folds chronologically

### DIFF
--- a/src/ml4t/diagnostic/splitters/walk_forward.py
+++ b/src/ml4t/diagnostic/splitters/walk_forward.py
@@ -711,8 +711,9 @@ class WalkForwardCV(BaseSplitter):
                 ←     ←     ←     ←     ←     ←     test_start
         ```
 
-        Validation folds step backward from the test boundary, ensuring that
-        all validation is done on data chronologically before the held-out test.
+        Validation folds are constructed backward from the test boundary, then
+        yielded in chronological order. This keeps all validation before the
+        held-out test while fold numbers increase with time.
         """
         # Validate inputs and get sample count
         n_samples = self._validate_data(X, y, groups)
@@ -1328,8 +1329,9 @@ class WalkForwardCV(BaseSplitter):
     ) -> Generator[tuple[NDArray[np.intp], NDArray[np.intp]], None, None]:
         """Generate splits stepping backward from held-out test boundary.
 
-        Validation folds step backward in time from the held-out test start,
-        ensuring all validation data is chronologically before the final test.
+        Validation folds are constructed backward in time from the held-out
+        test start, then yielded in chronological order. This ensures all
+        validation data is chronologically before the final test.
 
         ```
         [train1][val1][train2][val2][train3][val3] | [HELD-OUT TEST]
@@ -1372,10 +1374,9 @@ class WalkForwardCV(BaseSplitter):
         else:
             step_size = val_size  # Non-overlapping validation folds
 
-        # Generate splits stepping backward from test_start_idx
-        # Fold 0 has validation ending at test_start_idx
-        # Fold 1 has validation ending at test_start_idx - step_size
-        # etc.
+        # Construct splits backward from test_start_idx, then emit only the
+        # successfully constructed folds in chronological order.
+        backward_folds: list[tuple[NDArray[np.intp], NDArray[np.intp]]] = []
         for i in range(self.n_splits):
             # Validation fold boundaries (stepping backward)
             val_end = test_start_idx - i * step_size
@@ -1431,7 +1432,9 @@ class WalkForwardCV(BaseSplitter):
                     clean_train_indices, val_indices, groups
                 )
 
-            yield clean_train_indices, val_indices
+            backward_folds.append((clean_train_indices, val_indices))
+
+        yield from reversed(backward_folds)
 
     def _split_forward_with_test(
         self,

--- a/tests/test_splitters/test_fold_summary.py
+++ b/tests/test_splitters/test_fold_summary.py
@@ -183,7 +183,7 @@ class TestFoldSummary:
         assert len(cv.fold_summary_) == 3  # Still 3 folds, but from new data
 
     def test_fold_summary_held_out_test(self):
-        """Fold summary works with held-out test configuration."""
+        """Fold summary identifiers match chronological backward-fold emission."""
         dates = pd.date_range("2020-01-01", periods=500, freq="B", tz="UTC")
         df = pd.DataFrame({"value": np.random.randn(500)}, index=dates)
 
@@ -193,11 +193,13 @@ class TestFoldSummary:
             fold_direction="backward",
             label_horizon=5,
         )
-        for _ in cv.split(df):
-            pass
+        splits = list(cv.split(df))
 
         summary = cv.fold_summary_
         assert len(summary) <= 3
+        assert summary["fold"].tolist() == list(range(len(splits)))
+        assert summary["val_start"].is_monotonic_increasing
+        assert summary["val_start"].tolist() == [df.index[val_idx[0]] for _, val_idx in splits]
         # All validation should be before the held-out test start
         for _, row in summary.iterrows():
             assert row["val_end"] < pd.Timestamp("2021-06-01", tz="UTC")

--- a/tests/test_splitters/test_walk_forward_held_out.py
+++ b/tests/test_splitters/test_walk_forward_held_out.py
@@ -151,8 +151,8 @@ class TestHeldOutTestPeriod:
 class TestBackwardValidationFolds:
     """Test backward-stepping validation fold generation."""
 
-    def test_backward_folds_step_backward_from_test(self):
-        """Test that backward folds step backward from held-out test boundary."""
+    def test_backward_folds_are_emitted_in_chronological_order(self):
+        """Backward construction should not expose reverse chronological ordering."""
         n_samples = 200
         X = np.arange(n_samples).reshape(n_samples, 1)
 
@@ -167,15 +167,24 @@ class TestBackwardValidationFolds:
         splits = list(cv.split(X))
         test_start_idx = 170  # n_samples - test_period
 
-        # Validation folds should step backward from test_start_idx
-        val_ends = [val_idx.max() + 1 for _, val_idx in splits]
+        validation_windows = [(int(val_idx[0]), int(val_idx[-1]) + 1) for _, val_idx in splits]
 
-        # First fold's validation should end at test boundary
-        assert val_ends[0] == test_start_idx
+        assert validation_windows == [(110, 130), (130, 150), (150, test_start_idx)]
 
-        # Each subsequent fold should be further back
-        for i in range(1, len(val_ends)):
-            assert val_ends[i] < val_ends[i - 1]
+    def test_backward_folds_reverse_only_the_splits_that_fit(self):
+        """Chronological ordering should use the number of folds actually constructed."""
+        X = np.arange(100).reshape(100, 1)
+        cv = WalkForwardCV(
+            n_splits=5,
+            test_period=20,
+            test_size=30,
+            fold_direction="backward",
+        )
+
+        splits = list(cv.split(X))
+        validation_windows = [(int(val_idx[0]), int(val_idx[-1]) + 1) for _, val_idx in splits]
+
+        assert validation_windows == [(20, 50), (50, 80)]
 
     def test_backward_folds_no_overlap_with_test(self):
         """Test that backward validation folds don't overlap with held-out test."""


### PR DESCRIPTION
## Summary

- construct backward validation folds from the held-out test boundary as before
- emit only the folds actually constructed in chronological order
- keep `fold_summary_` identifiers aligned with emitted folds
- cover full and insufficient-history configurations

## Verification

- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run ty check`
- `uv run pytest tests/ -q -n auto --timeout 120` (5,336 passed, 75 skipped)
- `pre-commit run --all-files`

Closes #52