### PR TITLE
release: prepare ml4t-diagnostic 0.1.4

### DIFF
--- a/src/ml4t/diagnostic/__init__.py
+++ b/src/ml4t/diagnostic/__init__.py
@@ -31,7 +31,7 @@ This library follows semantic versioning. The public API consists of all symbols
 exported in __all__. Breaking changes will only occur in major version bumps.
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Sub-modules for advanced usage
 from . import (


### PR DESCRIPTION
## Summary

- bump the package version from 0.1.3 to 0.1.4
- release chronological fold identifiers for backward WalkForwardCV splits from #53

## Verification

- `uv run pytest tests/ -q -n auto --timeout 120`: 5,336 passed, 75 skipped
- `uv run ruff check src/`
- `uv run ruff format --check src/ tests/`
- `uv run ty check`
- `pre-commit run --all-files`
- built and verified both release artifacts
- installed the wheel in isolation and confirmed module and distribution metadata both report 0.1.4